### PR TITLE
fix: remove panic in internet errors to avoid crashing

### DIFF
--- a/auth/user.go
+++ b/auth/user.go
@@ -60,47 +60,54 @@ type User struct {
 	Properties map[string]string `json:"properties"`
 }
 
-func InitConfig(endpoint string, clientId string, clientSecret string, jwtSecret string) {
+func InitConfig(endpoint string, clientId string, clientSecret string, jwtSecret string, organizationName string) {
 	authConfig = AuthConfig{
-		Endpoint:     endpoint,
-		ClientId:     clientId,
-		ClientSecret: clientSecret,
-		JwtSecret:    jwtSecret,
+		Endpoint:         endpoint,
+		ClientId:         clientId,
+		ClientSecret:     clientSecret,
+		JwtSecret:        jwtSecret,
+		OrganizationName: organizationName,
 	}
 }
 
-func GetUsers() []*User {
+func GetUsers() ([]*User, error) {
 	url := fmt.Sprintf("%s/api/get-users?owner=%s", authConfig.Endpoint, authConfig.OrganizationName)
-	bytes := getBytes(url)
+	bytes, err := getBytes(url)
+	if err != nil {
+		return nil, err
+	}
 
 	var users []*User
-	err := json.Unmarshal(bytes, &users)
+	err = json.Unmarshal(bytes, &users)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return users
+	return users, nil
 }
 
-func GetUser(name string) *User {
+func GetUser(name string) (*User, error) {
 	url := fmt.Sprintf("%s/api/get-user?id=%s/%s", authConfig.Endpoint, authConfig.OrganizationName, name)
-	bytes := getBytes(url)
+	bytes, err := getBytes(url)
+	if err != nil {
+		return nil, err
+	}
 
 	var user *User
-	err := json.Unmarshal(bytes, &user)
+	err = json.Unmarshal(bytes, &user)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return user
+	return user, nil
 }
 
-func UpdateUser(user User) bool {
+func UpdateUser(user User) (bool, error) {
 	return modifyUser("update-user", user)
 }
 
-func AddUser(user User) bool {
+func AddUser(user User) (bool, error) {
 	return modifyUser("add-user", user)
 }
 
-func DeleteUser(user User) bool {
+func DeleteUser(user User) (bool, error) {
 	return modifyUser("delete-user", user)
 }

--- a/auth/util.go
+++ b/auth/util.go
@@ -29,22 +29,22 @@ type Response struct {
 	Data2  interface{} `json:"data2"`
 }
 
-func getBytes(url string) []byte {
+func getBytes(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return bytes
+	return bytes, nil
 }
 
-func modifyUser(method string, user User) bool {
+func modifyUser(method string, user User) (bool, error) {
 	user.Owner = authConfig.OrganizationName
 
 	url := fmt.Sprintf("%s/api/%s?id=%s/%s&clientId=%s&clientSecret=%s", authConfig.Endpoint, method, user.Owner, user.Name, authConfig.ClientId, authConfig.ClientSecret)
@@ -55,23 +55,23 @@ func modifyUser(method string, user User) bool {
 
 	resp, err := http.Post(url, "text/plain;charset=UTF-8", bytes.NewReader(userByte))
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 	defer resp.Body.Close()
 
 	respByte, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 
 	var response Response
 	err = json.Unmarshal(respByte, &response)
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 
 	if response.Data == "Affected" {
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }


### PR DESCRIPTION
After Casdoor backend throws an error, the front end will show beego panic pages (which is HTML text). SDK can not convert those texts into json, so the SDK will panic an error, which can stop the whole program. 
This PR is to ignore internet exceptions in such conditions.