### PR TITLE
fix: add missing error handling

### DIFF
--- a/casdoorsdk/base.go
+++ b/casdoorsdk/base.go
@@ -34,6 +34,9 @@ type Response struct {
 // DoGetResponse is a general function to get response from param url through HTTP Get method.
 func DoGetResponse(url string) (*Response, error) {
 	respBytes, err := DoGetBytesRaw(url)
+	if err != nil {
+		return nil, err
+	}
 
 	var response Response
 	err = json.Unmarshal(respBytes, &response)

--- a/casdoorsdk/token.go
+++ b/casdoorsdk/token.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GetOAuthToken gets the pivotal and necessary secret to interact with the Casdoor server
-func GetOAuthToken(code string) (*oauth2.Token, error) {
+func GetOAuthToken(code string, state string) (*oauth2.Token, error) {
 	config := oauth2.Config{
 		ClientID:     authConfig.ClientId,
 		ClientSecret: authConfig.ClientSecret,

--- a/casdoorsdk/token.go
+++ b/casdoorsdk/token.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GetOAuthToken gets the pivotal and necessary secret to interact with the Casdoor server
-func GetOAuthToken(code string, state string) (*oauth2.Token, error) {
+func GetOAuthToken(code string) (*oauth2.Token, error) {
 	config := oauth2.Config{
 		ClientID:     authConfig.ClientId,
 		ClientSecret: authConfig.ClientSecret,


### PR DESCRIPTION
The state parameter is not used, as a SDK, it should be deleted, otherwise it will cause trouble to users.