### PR TITLE
feat: unmarshal data from response model

### DIFF
--- a/casdoorsdk/permission.go
+++ b/casdoorsdk/permission.go
@@ -51,7 +51,7 @@ func GetPermissions() ([]*Permission, error) {
 
 	url := GetUrl("get-permissions", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func GetPermission(name string) (*Permission, error) {
 
 	url := GetUrl("get-permission", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}

--- a/casdoorsdk/resource.go
+++ b/casdoorsdk/resource.go
@@ -47,7 +47,7 @@ func GetResource(id string) (*Resource, error) {
 
 	url := GetUrl("get-resource", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func GetResources(owner, user, field, value, sortField, sortOrder string) ([]*Re
 
 	url := GetUrl("get-resources", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func GetPaginationResources(owner, user, field, value string, pageSize, page int
 
 	url := GetUrl("get-resources", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}

--- a/casdoorsdk/role.go
+++ b/casdoorsdk/role.go
@@ -40,7 +40,7 @@ func GetRoles() ([]*Role, error) {
 
 	url := GetUrl("get-roles", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func GetRole(name string) (*Role, error) {
 
 	url := GetUrl("get-role", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}

--- a/casdoorsdk/user.go
+++ b/casdoorsdk/user.go
@@ -202,7 +202,7 @@ func GetSortedUsers(sorter string, limit int) ([]*User, error) {
 
 	url := GetUrl("get-sorted-users", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func GetUserCount(isOnline string) (int, error) {
 
 	url := GetUrl("get-user-count", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return -1, err
 	}

--- a/casdoorsdk/user.go
+++ b/casdoorsdk/user.go
@@ -158,8 +158,8 @@ type User struct {
 	Zoom            string `xorm:"zoom varchar(100)" json:"zoom"`
 	Custom          string `xorm:"custom varchar(100)" json:"custom"`
 
-	//WebauthnCredentials []webauthn.Credential `xorm:"webauthnCredentials blob" json:"webauthnCredentials"`
-	//MultiFactorAuths    []*MfaProps           `json:"multiFactorAuths"`
+	// WebauthnCredentials []webauthn.Credential `xorm:"webauthnCredentials blob" json:"webauthnCredentials"`
+	// MultiFactorAuths    []*MfaProps           `json:"multiFactorAuths"`
 
 	Ldap       string            `xorm:"ldap varchar(100)" json:"ldap"`
 	Properties map[string]string `json:"properties"`
@@ -180,7 +180,7 @@ func GetUsers() ([]*User, error) {
 
 	url := GetUrl("get-users", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func GetUser(name string) (*User, error) {
 
 	url := GetUrl("get-user", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func GetUserByEmail(email string) (*User, error) {
 
 	url := GetUrl("get-user", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func GetUserByPhone(phone string) (*User, error) {
 
 	url := GetUrl("get-user", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func GetUserByUserId(userId string) (*User, error) {
 
 	url := GetUrl("get-user", queryMap)
 
-	bytes, err := DoGetBytesRaw(url)
+	bytes, err := DoGetBytes(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
formatted with gofumpt
solved: #71 

Need to mention that in casdoor `/api/get-sorted-users` and `/api/get-user-count` reponse are not replaced by responseOk. So in sdk I left them unchanged in my commit. Is this already enough or `get-sorted-users` and `get-user-count` will be changed later? 