### PR TITLE
fix: fixed getting users by only email, phone or userId without owner

### DIFF
--- a/casdoorsdk/test_util.go
+++ b/casdoorsdk/test_util.go
@@ -71,3 +71,7 @@ func getRandomCode(length int) string {
 func getRandomName(prefix string) string {
 	return fmt.Sprintf("%s_%s", prefix, getRandomCode(6))
 }
+
+func getRandomEmail(prefix string) string {
+	return fmt.Sprintf("%s_%s@example.com", prefix, getRandomCode(6))
+}

--- a/casdoorsdk/user.go
+++ b/casdoorsdk/user.go
@@ -326,7 +326,6 @@ func (c *Client) GetUser(name string) (*User, error) {
 
 func (c *Client) GetUserByEmail(email string) (*User, error) {
 	queryMap := map[string]string{
-		"owner": c.OrganizationName,
 		"email": email,
 	}
 
@@ -347,7 +346,6 @@ func (c *Client) GetUserByEmail(email string) (*User, error) {
 
 func (c *Client) GetUserByPhone(phone string) (*User, error) {
 	queryMap := map[string]string{
-		"owner": c.OrganizationName,
 		"phone": phone,
 	}
 
@@ -368,7 +366,6 @@ func (c *Client) GetUserByPhone(phone string) (*User, error) {
 
 func (c *Client) GetUserByUserId(userId string) (*User, error) {
 	queryMap := map[string]string{
-		"owner":  c.OrganizationName,
 		"userId": userId,
 	}
 

--- a/casdoorsdk/user_test.go
+++ b/casdoorsdk/user_test.go
@@ -15,6 +15,7 @@
 package casdoorsdk
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -22,11 +23,17 @@ func TestUser(t *testing.T) {
 	InitConfig(TestCasdoorEndpoint, TestClientId, TestClientSecret, TestJwtPublicKey, TestCasdoorOrganization, TestCasdoorApplication)
 
 	name := getRandomName("User")
+	id := getRandomCode(25)
+	email := getRandomEmail("test_user")
+	phone := getRandomCode(10)
 
 	// Add a new object
 	user := &User{
 		Owner:       TestCasdoorOrganization,
+		Id:          id,
 		Name:        name,
+		Email:       email,
+		Phone:       phone,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,
 	}
@@ -58,6 +65,33 @@ func TestUser(t *testing.T) {
 	}
 	if user.Name != name {
 		t.Fatalf("Retrieved object does not match added object: %s != %s", user.Name, name)
+	}
+
+	// Get the object by email
+	user, err = GetUserByEmail(email)
+	if user == nil {
+		err = errors.New("the added object is not found")
+	}
+	if err != nil {
+		t.Fatalf("Failed to get object: %v", err)
+	}
+
+	// Get the object by phone
+	user, err = GetUserByPhone(phone)
+	if user == nil {
+		err = errors.New("the added object is not found")
+	}
+	if err != nil {
+		t.Fatalf("Failed to get object: %v", err)
+	}
+	
+	// Get the object by id
+	user, err = GetUserByUserId(id)
+	if user == nil {
+		err = errors.New("the added object is not found")
+	}
+	if err != nil {
+		t.Fatalf("Failed to get object: %v", err)
 	}
 
 	// Update the object


### PR DESCRIPTION
Hello,

When I was testing the different ways to obtain a single user, I figured out that the owner was being passed into the request. This caused the responses to be HTML error pages by Beego.

According to the [PR](https://github.com/casbin/casdoor/pull/2398/files), the owner does not need to be passed in.

I removed the owner parameter and added the accompanying tests


