### PR TITLE
feat: Add JWT token type

### DIFF
--- a/casdoorsdk/jwt.go
+++ b/casdoorsdk/jwt.go
@@ -24,6 +24,12 @@ type Claims struct {
 	User
 	AccessToken string `json:"accessToken"`
 	jwt.RegisteredClaims
+	TokenType string `json:"TokenType"`
+}
+
+// IsRefreshToken returns true if the token is a refresh token
+func (c Claims) IsRefreshToken() bool {
+	return c.TokenType == "refresh-token"
 }
 
 func (c *Client) ParseJwtToken(token string) (*Claims, error) {


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-go-sdk/issues/99#issuecomment-1954464072

Add `TokenType` field to `casdoorsdk.Claims`.
Add `IsRefreshToken` func to `casdoorsdk.Claims`.
This feature will let you find out if you are dealing with refresh token or access token.