### PR TITLE
feat: fix GetPaginationUsers error: "response data format is incorrect"

### DIFF
--- a/casdoorsdk/user.go
+++ b/casdoorsdk/user.go
@@ -275,8 +275,14 @@ func (c *Client) GetPaginationUsers(p int, pageSize int, queryMap map[string]str
 		return nil, 0, err
 	}
 
-	users, ok := response.Data.([]*User)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var users []*User
+	err = json.Unmarshal(dataBytes, &users)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 


### PR DESCRIPTION
An error message `response data format is incorrect` appears when using the `GetPaginationUsers` function with the parameter "groupName": "xx". I have tried to fix it.

Error reproduction steps：
```golang
pUsers, count, err := casdoor.Cli.GetPaginationUsers(page, 100, map[string]string{
	"groupName": "xxx",
})
```