### PR TITLE
feat: fix all GetPagination methods error: "response data format is incorrect"

### DIFF
--- a/casdoorsdk/adapter.go
+++ b/casdoorsdk/adapter.go
@@ -74,8 +74,14 @@ func (c *Client) GetPaginationAdapters(p int, pageSize int, queryMap map[string]
 		return nil, 0, err
 	}
 
-	adapters, ok := response.Data.([]*Adapter)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var adapters []*Adapter
+	err = json.Unmarshal(dataBytes, &adapters)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/enforcer.go
+++ b/casdoorsdk/enforcer.go
@@ -68,8 +68,14 @@ func (c *Client) GetPaginationEnforcers(p int, pageSize int, queryMap map[string
 		return nil, 0, err
 	}
 
-	enforcers, ok := response.Data.([]*Enforcer)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var enforcers []*Enforcer
+	err = json.Unmarshal(dataBytes, &enforcers)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/group.go
+++ b/casdoorsdk/group.go
@@ -27,13 +27,13 @@ type Group struct {
 	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
 	UpdatedTime string `xorm:"varchar(100)" json:"updatedTime"`
 
-	DisplayName  string  `xorm:"varchar(100)" json:"displayName"`
-	Manager      string  `xorm:"varchar(100)" json:"manager"`
-	ContactEmail string  `xorm:"varchar(100)" json:"contactEmail"`
-	Type         string  `xorm:"varchar(100)" json:"type"`
-	ParentId     string  `xorm:"varchar(100)" json:"parentId"`
-	IsTopGroup   bool    `xorm:"bool" json:"isTopGroup"`
-	Users        []*User `xorm:"-" json:"users"`
+	DisplayName  string   `xorm:"varchar(100)" json:"displayName"`
+	Manager      string   `xorm:"varchar(100)" json:"manager"`
+	ContactEmail string   `xorm:"varchar(100)" json:"contactEmail"`
+	Type         string   `xorm:"varchar(100)" json:"type"`
+	ParentId     string   `xorm:"varchar(100)" json:"parentId"`
+	IsTopGroup   bool     `xorm:"bool" json:"isTopGroup"`
+	Users        []string `xorm:"mediumtext" json:"users"`
 
 	Title    string   `json:"title,omitempty"`
 	Key      string   `json:"key,omitempty"`
@@ -74,8 +74,14 @@ func (c *Client) GetPaginationGroups(p int, pageSize int, queryMap map[string]st
 		return nil, 0, err
 	}
 
-	groups, ok := response.Data.([]*Group)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var groups []*Group
+	err = json.Unmarshal(dataBytes, &groups)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/model.go
+++ b/casdoorsdk/model.go
@@ -40,7 +40,7 @@ type Model struct {
 	Children []*Model `json:"children,omitempty"`
 
 	ModelText string `xorm:"mediumtext" json:"modelText"`
-	IsEnabled bool `json:"isEnabled"`
+	IsEnabled bool   `json:"isEnabled"`
 }
 
 func (c *Client) GetModels() ([]*Model, error) {
@@ -75,8 +75,14 @@ func (c *Client) GetPaginationModels(p int, pageSize int, queryMap map[string]st
 		return nil, 0, err
 	}
 
-	models, ok := response.Data.([]*Model)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var models []*Model
+	err = json.Unmarshal(dataBytes, &models)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/payment.go
+++ b/casdoorsdk/payment.go
@@ -89,8 +89,14 @@ func (c *Client) GetPaginationPayments(p int, pageSize int, queryMap map[string]
 		return nil, 0, err
 	}
 
-	payments, ok := response.Data.([]*Payment)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var payments []*Payment
+	err = json.Unmarshal(dataBytes, &payments)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/permission.go
+++ b/casdoorsdk/permission.go
@@ -99,8 +99,14 @@ func (c *Client) GetPaginationPermissions(p int, pageSize int, queryMap map[stri
 		return nil, 0, err
 	}
 
-	permissions, ok := response.Data.([]*Permission)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var permissions []*Permission
+	err = json.Unmarshal(dataBytes, &permissions)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/plan.go
+++ b/casdoorsdk/plan.go
@@ -70,8 +70,14 @@ func (c *Client) GetPaginationPlans(p int, pageSize int, queryMap map[string]str
 		return nil, 0, err
 	}
 
-	plans, ok := response.Data.([]*Plan)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var plans []*Plan
+	err = json.Unmarshal(dataBytes, &plans)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/pricing.go
+++ b/casdoorsdk/pricing.go
@@ -73,8 +73,14 @@ func (c *Client) GetPaginationPricings(p int, pageSize int, queryMap map[string]
 		return nil, 0, err
 	}
 
-	pricings, ok := response.Data.([]*Pricing)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var pricings []*Pricing
+	err = json.Unmarshal(dataBytes, &pricings)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/product.go
+++ b/casdoorsdk/product.go
@@ -75,8 +75,14 @@ func (c *Client) GetPaginationProducts(p int, pageSize int, queryMap map[string]
 		return nil, 0, err
 	}
 
-	products, ok := response.Data.([]*Product)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var products []*Product
+	err = json.Unmarshal(dataBytes, &products)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/provider.go
+++ b/casdoorsdk/provider.go
@@ -120,10 +120,18 @@ func (c *Client) GetPaginationProviders(p int, pageSize int, queryMap map[string
 	if err != nil {
 		return nil, 0, err
 	}
-	providers, ok := response.Data.([]*Provider)
-	if !ok {
+
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var providers []*Provider
+	err = json.Unmarshal(dataBytes, &providers)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
+
 	return providers, int(response.Data2.(float64)), nil
 }
 

--- a/casdoorsdk/record.go
+++ b/casdoorsdk/record.go
@@ -73,8 +73,14 @@ func (c *Client) GetPaginationRecords(p int, pageSize int, queryMap map[string]s
 		return nil, 0, err
 	}
 
-	records, ok := response.Data.([]*Record)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var records []*Record
+	err = json.Unmarshal(dataBytes, &records)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/role.go
+++ b/casdoorsdk/role.go
@@ -68,10 +68,17 @@ func (c *Client) GetPaginationRoles(p int, pageSize int, queryMap map[string]str
 		return nil, 0, err
 	}
 
-	roles, ok := response.Data.([]*Role)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var roles []*Role
+	err = json.Unmarshal(dataBytes, &roles)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
+
 	return roles, int(response.Data2.(float64)), nil
 }
 

--- a/casdoorsdk/session.go
+++ b/casdoorsdk/session.go
@@ -67,8 +67,14 @@ func (c *Client) GetPaginationSessions(p int, pageSize int, queryMap map[string]
 		return nil, 0, err
 	}
 
-	sessions, ok := response.Data.([]*Session)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var sessions []*Session
+	err = json.Unmarshal(dataBytes, &sessions)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 	return sessions, int(response.Data2.(float64)), nil

--- a/casdoorsdk/subscription.go
+++ b/casdoorsdk/subscription.go
@@ -76,10 +76,18 @@ func (c *Client) GetPaginationSubscriptions(p int, pageSize int, queryMap map[st
 	if err != nil {
 		return nil, 0, err
 	}
-	subscriptions, ok := response.Data.([]*Subscription)
-	if !ok {
+
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var subscriptions []*Subscription
+	err = json.Unmarshal(dataBytes, &subscriptions)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
+
 	return subscriptions, int(response.Data2.(float64)), nil
 }
 

--- a/casdoorsdk/syncer.go
+++ b/casdoorsdk/syncer.go
@@ -90,8 +90,14 @@ func (c *Client) GetPaginationSyncers(p int, pageSize int, queryMap map[string]s
 		return nil, 0, err
 	}
 
-	syncers, ok := response.Data.([]*Syncer)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var syncers []*Syncer
+	err = json.Unmarshal(dataBytes, &syncers)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/token.go
+++ b/casdoorsdk/token.go
@@ -90,8 +90,14 @@ func (c *Client) GetPaginationTokens(p int, pageSize int, queryMap map[string]st
 		return nil, 0, err
 	}
 
-	tokens, ok := response.Data.([]*Token)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var tokens []*Token
+	err = json.Unmarshal(dataBytes, &tokens)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/transaction.go
+++ b/casdoorsdk/transaction.go
@@ -79,8 +79,14 @@ func (c *Client) GetPaginationTransactions(p int, pageSize int, queryMap map[str
 		return nil, 0, err
 	}
 
-	transactions, ok := response.Data.([]*Transaction)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var transactions []*Transaction
+	err = json.Unmarshal(dataBytes, &transactions)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 

--- a/casdoorsdk/webhook.go
+++ b/casdoorsdk/webhook.go
@@ -81,8 +81,14 @@ func (c *Client) GetPaginationWebhooks(p int, pageSize int, queryMap map[string]
 		return nil, 0, err
 	}
 
-	webhooks, ok := response.Data.([]*Webhook)
-	if !ok {
+	dataBytes, err := json.Marshal(response.Data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var webhooks []*Webhook
+	err = json.Unmarshal(dataBytes, &webhooks)
+	if err != nil {
 		return nil, 0, errors.New("response data format is incorrect")
 	}
 


### PR DESCRIPTION
fix same problem #106 but for other methods

the solution of "response data format is incorrect" I've found [here](https://github.com/casdoor/casdoor-go-sdk/commit/8987bae9f2ecdde6b7928c876a2b910b55e56653)