### PR TITLE
fix:permission name not exist,permission variable is nil

### DIFF
--- a/casdoorsdk/permission.go
+++ b/casdoorsdk/permission.go
@@ -130,6 +130,9 @@ func (c *Client) GetPermission(name string) (*Permission, error) {
 	if err != nil {
 		return nil, err
 	}
+	if permission == nil {
+		return nil, errors.New("permission not found")
+	}
 	return permission, nil
 }
 


### PR DESCRIPTION
When the requested permission ID does not exist, the function does not return any error, and permission variable is nil.When you use this variable outside, it triggers panic