### PR TITLE
feat: escape URL params in GetUrl()

### DIFF
--- a/casdoorsdk/util.go
+++ b/casdoorsdk/util.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -29,12 +30,11 @@ import (
 func (c *Client) GetUrl(action string, queryMap map[string]string) string {
 	query := ""
 	for k, v := range queryMap {
-		query += fmt.Sprintf("%s=%s&", k, v)
+		query += fmt.Sprintf("%s=%s&", url.QueryEscape(k), url.QueryEscape(v))
 	}
 	query = strings.TrimRight(query, "&")
 
-	url := fmt.Sprintf("%s/api/%s?%s", c.Endpoint, action, query)
-	return url
+	return fmt.Sprintf("%s/api/%s?%s", c.Endpoint, action, query)
 }
 
 func (c *Client) GetId(name string) string {


### PR DESCRIPTION
Data in url should be escaped.
For example, I have faced issue: 
> try to find user with email `user+test1@gmail.com`

Without escaping it passed to url as is, and then at serverside (by casdoor api) it parser as `user test1@gmail.com` (because "+" - is encoded value of space char).
We need to put "%2B" instead of "+" in url params.