### PR TITLE
fix: CheckUserPassword returns correct result for valid passwords

### DIFF
--- a/casdoorsdk/util_modify.go
+++ b/casdoorsdk/util_modify.go
@@ -154,6 +154,10 @@ func (c *Client) modifyUserById(action string, id string, user *User, columns []
 		return nil, false, err
 	}
 
+	if action == "check-user-password" {
+		return resp, resp.Status == "ok", nil
+	}
+	
 	return resp, resp.Data == "Affected", nil
 }
 


### PR DESCRIPTION
fixes #154

```json
response date:

{
  "status": "ok",
  "msg": "",
  "data": null,
  "data2": null
}
```

So I used `resp.Status == "ok"` to check whether this request is correct.