### PR TITLE
feat: add 'Language', 'StatusCode', and 'Response' fields to Record struct

### DIFF
--- a/casdoorsdk/record.go
+++ b/casdoorsdk/record.go
@@ -36,6 +36,7 @@ type Record struct {
 	Action       string `xorm:"varchar(1000)" json:"action"`
 	Language     string `xorm:"varchar(100)" json:"language"`
 
+	StatusCode   int    `xorm:"-" json:"statusCode"`
 	Response     string `xorm:"-" json:"response"`
 	Object       string `xorm:"-" json:"object"`
 	ExtendedUser *User  `xorm:"-" json:"extendedUser"`


### PR DESCRIPTION
Fix: #216 

## Background

Currently, there's no `StatusCode`, `Response`, and `Language` fields on `Record` struct so the value of those fields is empty when the record being inserted with `AddRecord`function

## Changes
- add 'Language', 'StatusCode', and 'Response' field on Record struct

## Example
```go
record := &casdoorsdk.Record{
	Owner:        organization,
	Name:         fmt.Sprintf("rec_%d", time.Now().UnixNano()),
	CreatedTime:  time.Now().Format(time.RFC3339),
	Organization: organization,
	ClientIp:     c.ClientIP(),
	User:         username,
	Method:       c.Request.Method,
	RequestUri:   c.Request.URL.Path,
	Action:       fmt.Sprintf("%s %s | Status: %d", c.Request.Method, c.Request.URL.Path, c.Writer.Status()),
	Object:       c.Request.URL.Path,
	IsTriggered:  false,
	Response:     "{\"status_code\": 200, \"message\": \"ok\"}",
	Language:     "en",
	StatusCode:   http.StatusOK,
}

go func(r *casdoorsdk.Record) {
        _, err := casdoorsdk.AddRecord(r)
        if err != nil {
        log.Printf("Failed to log record to Casdoor: %v", err)
}
}(record)
```