### PR TITLE
feat: sync struct fields with upstream Casdoor and fix fmt.Errorf misuse

### DIFF
--- a/casdoorsdk/adapter.go
+++ b/casdoorsdk/adapter.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -90,7 +89,7 @@ func (c *Client) GetPaginationAdapters(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetAdapter(name string) (*Adapter, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-adapter", queryMap)

--- a/casdoorsdk/application.go
+++ b/casdoorsdk/application.go
@@ -23,13 +23,14 @@ type ProviderItem struct {
 	Owner string `json:"owner"`
 	Name  string `json:"name"`
 
-	CanSignUp bool      `json:"canSignUp"`
-	CanSignIn bool      `json:"canSignIn"`
-	CanUnlink bool      `json:"canUnlink"`
-	Prompted  bool      `json:"prompted"`
-	AlertType string    `json:"alertType"`
-	Rule      string    `json:"rule"`
-	Provider  *Provider `json:"provider"`
+	CanSignUp    bool      `json:"canSignUp"`
+	CanSignIn    bool      `json:"canSignIn"`
+	CanUnlink    bool      `json:"canUnlink"`
+	CountryCodes []string  `json:"countryCodes"`
+	Prompted     bool      `json:"prompted"`
+	SignupGroup  string    `json:"signupGroup"`
+	Rule         string    `json:"rule"`
+	Provider     *Provider `json:"provider"`
 }
 
 type SignupItem struct {
@@ -74,6 +75,13 @@ type JwtItem struct {
 	Type  string `json:"type"`
 }
 
+type ScopeItem struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName"`
+	Description string   `json:"description"`
+	Tools       []string `json:"tools"` // MCP tools allowed by this scope
+}
+
 // Application has the same definition as https://github.com/casdoor/casdoor/blob/master/object/application.go#L61
 type Application struct {
 	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
@@ -81,6 +89,9 @@ type Application struct {
 	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
 
 	DisplayName                  string          `xorm:"varchar(100)" json:"displayName"`
+	Category                     string          `xorm:"varchar(100)" json:"category"`
+	Type                         string          `xorm:"varchar(20)" json:"type"`
+	Scopes                       []*ScopeItem    `xorm:"mediumtext" json:"scopes"`
 	Logo                         string          `xorm:"varchar(200)" json:"logo"`
 	Title                        string          `xorm:"varchar(100)" json:"title"`
 	Favicon                      string          `xorm:"varchar(200)" json:"favicon"`
@@ -152,6 +163,13 @@ type Application struct {
 	FailedSigninLimit      int `json:"failedSigninLimit"`
 	FailedSigninFrozenTime int `json:"failedSigninFrozenTime"`
 	CodeResendTimeout      int `json:"codeResendTimeout"`
+
+	// Reverse proxy fields
+	Domain       string   `xorm:"varchar(100)" json:"domain"`
+	OtherDomains []string `xorm:"varchar(1000)" json:"otherDomains"`
+	UpstreamHost string   `xorm:"varchar(100)" json:"upstreamHost"`
+	SslMode      string   `xorm:"varchar(100)" json:"sslMode"`
+	SslCert      string   `xorm:"varchar(100)" json:"sslCert"`
 
 	CertObj *Cert `xorm:"-" json:"certObj"`
 }

--- a/casdoorsdk/application.go
+++ b/casdoorsdk/application.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type ProviderItem struct {
@@ -217,7 +216,7 @@ func (c *Client) GetOrganizationApplications() ([]*Application, error) {
 
 func (c *Client) GetApplication(name string) (*Application, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", name),
+		"id": getAdminId(name),
 	}
 
 	url := c.GetUrl("get-application", queryMap)

--- a/casdoorsdk/cert.go
+++ b/casdoorsdk/cert.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // Cert has the same definition as https://github.com/casdoor/casdoor/blob/master/object/cert.go#L24
@@ -76,7 +75,7 @@ func (c *Client) GetCerts() ([]*Cert, error) {
 
 func (c *Client) GetCert(name string) (*Cert, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-cert", queryMap)

--- a/casdoorsdk/enforcer.go
+++ b/casdoorsdk/enforcer.go
@@ -29,9 +29,11 @@ type Enforcer struct {
 	DisplayName string `xorm:"varchar(100)" json:"displayName"`
 	Description string `xorm:"varchar(100)" json:"description"`
 
-	Model     string `xorm:"varchar(100)" json:"model"`
-	Adapter   string `xorm:"varchar(100)" json:"adapter"`
-	IsEnabled bool   `json:"isEnabled"`
+	Model    string            `xorm:"varchar(100)" json:"model"`
+	Adapter  string            `xorm:"varchar(100)" json:"adapter"`
+	ModelCfg map[string]string `xorm:"-" json:"modelCfg"`
+
+	IsEnabled bool `json:"isEnabled"`
 
 	//*casbin.Enforcer
 }

--- a/casdoorsdk/enforcer.go
+++ b/casdoorsdk/enforcer.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -86,7 +85,7 @@ func (c *Client) GetPaginationEnforcers(p int, pageSize int, queryMap map[string
 
 func (c *Client) GetEnforcer(name string) (*Enforcer, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-enforcer", queryMap)

--- a/casdoorsdk/group.go
+++ b/casdoorsdk/group.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -36,7 +35,7 @@ type Group struct {
 	IsTopGroup   bool     `xorm:"bool" json:"isTopGroup"`
 	Users        []string `xorm:"mediumtext" json:"users"`
 
-	Title    string   `json:"title,omitempty"`
+	Title        string   `json:"title,omitempty"`
 	Key          string   `json:"key,omitempty"`
 	HaveChildren bool     `xorm:"-" json:"haveChildren"`
 	Children     []*Group `json:"children,omitempty"`
@@ -92,7 +91,7 @@ func (c *Client) GetPaginationGroups(p int, pageSize int, queryMap map[string]st
 
 func (c *Client) GetGroup(name string) (*Group, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-group", queryMap)

--- a/casdoorsdk/group.go
+++ b/casdoorsdk/group.go
@@ -32,12 +32,14 @@ type Group struct {
 	ContactEmail string   `xorm:"varchar(100)" json:"contactEmail"`
 	Type         string   `xorm:"varchar(100)" json:"type"`
 	ParentId     string   `xorm:"varchar(100)" json:"parentId"`
+	ParentName   string   `xorm:"-" json:"parentName"`
 	IsTopGroup   bool     `xorm:"bool" json:"isTopGroup"`
 	Users        []string `xorm:"mediumtext" json:"users"`
 
 	Title    string   `json:"title,omitempty"`
-	Key      string   `json:"key,omitempty"`
-	Children []*Group `json:"children,omitempty"`
+	Key          string   `json:"key,omitempty"`
+	HaveChildren bool     `xorm:"-" json:"haveChildren"`
+	Children     []*Group `json:"children,omitempty"`
 
 	IsEnabled bool `json:"isEnabled"`
 }

--- a/casdoorsdk/invitation.go
+++ b/casdoorsdk/invitation.go
@@ -92,7 +92,7 @@ func (c *Client) GetPaginationInvitations(p int, pageSize int, queryMap map[stri
 
 func (c *Client) GetInvitation(name string) (*Invitation, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-invitation", queryMap)

--- a/casdoorsdk/ldap.go
+++ b/casdoorsdk/ldap.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type Ldap struct {
@@ -98,7 +97,7 @@ func (c *Client) GetLdaps() ([]*Ldap, error) {
 
 func (c *Client) GetLdap(id string) (*Ldap, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", id),
+		"id": getAdminId(id),
 	}
 
 	url := c.GetUrl("get-ldap", queryMap)
@@ -133,7 +132,7 @@ func (c *Client) UpdateLdap(ldap *Ldap) (bool, error) {
 
 func (c *Client) GetLdapUsers(id string) (*LdapUsersResponse, error) {
 	url := c.GetUrl("get-ldap-users", map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, id),
+		"id": c.GetId(id),
 	})
 
 	bytes, err := c.DoGetBytes(url)
@@ -151,7 +150,7 @@ func (c *Client) GetLdapUsers(id string) (*LdapUsersResponse, error) {
 
 func (c *Client) SyncLdapUsers(id string, users []*LdapUser) (*SyncLdapUsersResponse, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, id),
+		"id": c.GetId(id),
 	}
 
 	postBytes, err := json.Marshal(users)

--- a/casdoorsdk/model.go
+++ b/casdoorsdk/model.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -92,7 +91,7 @@ func (c *Client) GetPaginationModels(p int, pageSize int, queryMap map[string]st
 
 func (c *Client) GetModel(name string) (*Model, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-model", queryMap)

--- a/casdoorsdk/model.go
+++ b/casdoorsdk/model.go
@@ -28,6 +28,7 @@ type Model struct {
 	UpdatedTime string `xorm:"varchar(100)" json:"updatedTime"`
 
 	DisplayName  string  `xorm:"varchar(100)" json:"displayName"`
+	Description  string  `xorm:"varchar(100)" json:"description"`
 	Manager      string  `xorm:"varchar(100)" json:"manager"`
 	ContactEmail string  `xorm:"varchar(100)" json:"contactEmail"`
 	Type         string  `xorm:"varchar(100)" json:"type"`

--- a/casdoorsdk/order.go
+++ b/casdoorsdk/order.go
@@ -126,7 +126,7 @@ func (c *Client) GetUserOrders(userName string) ([]*Order, error) {
 
 func (c *Client) GetOrder(name string) (*Order, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-order", queryMap)
@@ -160,7 +160,7 @@ func (c *Client) DeleteOrder(order *Order) (bool, error) {
 
 func (c *Client) CancelOrder(name string) (bool, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	resp, err := c.DoPost("cancel-order", queryMap, []byte(""), false, false)

--- a/casdoorsdk/organization.go
+++ b/casdoorsdk/organization.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type AccountItem struct {
@@ -95,7 +94,7 @@ type Organization struct {
 
 func (c *Client) GetOrganization(name string) (*Organization, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", name),
+		"id": getAdminId(name),
 	}
 
 	url := c.GetUrl("get-organization", queryMap)

--- a/casdoorsdk/organization.go
+++ b/casdoorsdk/organization.go
@@ -82,7 +82,10 @@ type Organization struct {
 
 	MfaItems           []*MfaItem     `xorm:"varchar(300)" json:"mfaItems"`
 	MfaRememberInHours int            `json:"mfaRememberInHours"`
+	AccountMenu        string         `xorm:"varchar(20)" json:"accountMenu"`
 	AccountItems       []*AccountItem `xorm:"mediumtext" json:"accountItems"`
+
+	DcrPolicy string `xorm:"varchar(100)" json:"dcrPolicy"`
 
 	OrgBalance      float64 `json:"orgBalance"`
 	UserBalance     float64 `json:"userBalance"`

--- a/casdoorsdk/payment.go
+++ b/casdoorsdk/payment.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -106,7 +105,7 @@ func (c *Client) GetPaginationPayments(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetPayment(name string) (*Payment, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-payment", queryMap)

--- a/casdoorsdk/permission.go
+++ b/casdoorsdk/permission.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -69,7 +68,7 @@ func (c *Client) GetPermissions() ([]*Permission, error) {
 
 func (c *Client) GetPermissionsByRole(name string) ([]*Permission, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-permissions-by-role", queryMap)
@@ -115,7 +114,7 @@ func (c *Client) GetPaginationPermissions(p int, pageSize int, queryMap map[stri
 
 func (c *Client) GetPermission(name string) (*Permission, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-permission", queryMap)

--- a/casdoorsdk/plan.go
+++ b/casdoorsdk/plan.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -88,7 +87,7 @@ func (c *Client) GetPaginationPlans(p int, pageSize int, queryMap map[string]str
 
 func (c *Client) GetPlan(name string) (*Plan, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-plan", queryMap)

--- a/casdoorsdk/pricing.go
+++ b/casdoorsdk/pricing.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -89,7 +88,7 @@ func (c *Client) GetPaginationPricings(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetPricing(name string) (*Pricing, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-pricing", queryMap)

--- a/casdoorsdk/product.go
+++ b/casdoorsdk/product.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -94,7 +93,7 @@ func (c *Client) GetPaginationProducts(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetProduct(name string) (*Product, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-product", queryMap)

--- a/casdoorsdk/provider.go
+++ b/casdoorsdk/provider.go
@@ -42,10 +42,12 @@ type Provider struct {
 	CustomLogo        string            `xorm:"varchar(200)" json:"customLogo"`
 	Scopes            string            `xorm:"varchar(100)" json:"scopes"`
 	UserMapping       map[string]string `xorm:"varchar(500)" json:"userMapping"`
+	HttpHeaders       map[string]string `xorm:"varchar(500)" json:"httpHeaders"`
 
 	Host       string `xorm:"varchar(100)" json:"host"`
 	Port       int    `json:"port"`
-	DisableSsl bool   `json:"disableSsl"` // If the provider type is WeChat, DisableSsl means EnableQRCode
+	DisableSsl bool   `json:"disableSsl"`                  // Deprecated: Use SslMode instead. If the provider type is WeChat, DisableSsl means EnableQRCode, if type is Google, it means sync phone number
+	SslMode    string `xorm:"varchar(100)" json:"sslMode"` // "Auto" (empty means Auto), "Enable", "Disable"
 	Title      string `xorm:"varchar(100)" json:"title"`
 	Content    string `xorm:"varchar(1000)" json:"content"` // If provider type is WeChat, Content means QRCode string by Base64 encoding
 	Receiver   string `xorm:"varchar(100)" json:"receiver"`
@@ -65,8 +67,11 @@ type Provider struct {
 	IdP                    string `xorm:"mediumtext" json:"idP"`
 	IssuerUrl              string `xorm:"varchar(100)" json:"issuerUrl"`
 	EnableSignAuthnRequest bool   `json:"enableSignAuthnRequest"`
+	EmailRegex             string `xorm:"varchar(200)" json:"emailRegex"`
 
 	ProviderUrl string `xorm:"varchar(200)" json:"providerUrl"`
+	EnableProxy bool   `json:"enableProxy"`
+	EnablePkce  bool   `json:"enablePkce"`
 }
 
 func (c *Client) GetProviders() ([]*Provider, error) {

--- a/casdoorsdk/provider.go
+++ b/casdoorsdk/provider.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -96,7 +95,7 @@ func (c *Client) GetProviders() ([]*Provider, error) {
 
 func (c *Client) GetProvider(name string) (*Provider, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-provider", queryMap)

--- a/casdoorsdk/record.go
+++ b/casdoorsdk/record.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -92,7 +91,7 @@ func (c *Client) GetPaginationRecords(p int, pageSize int, queryMap map[string]s
 
 func (c *Client) GetRecord(name string) (*Record, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-record", queryMap)

--- a/casdoorsdk/record.go
+++ b/casdoorsdk/record.go
@@ -36,12 +36,12 @@ type Record struct {
 	Action       string `xorm:"varchar(1000)" json:"action"`
 	Language     string `xorm:"varchar(100)" json:"language"`
 
-	StatusCode   int    `xorm:"-" json:"statusCode"`
-	Response     string `xorm:"-" json:"response"`
-	Object       string `xorm:"-" json:"object"`
-	ExtendedUser *User  `xorm:"-" json:"extendedUser"`
+	Object   string `xorm:"mediumtext" json:"object"`
+	Response string `xorm:"mediumtext" json:"response"`
 
-	IsTriggered bool `json:"isTriggered"`
+	Provider    string `xorm:"varchar(100)" json:"provider"`
+	Block       string `xorm:"varchar(100)" json:"block"`
+	IsTriggered bool   `json:"isTriggered"`
 }
 
 func (c *Client) GetRecords() ([]*Record, error) {

--- a/casdoorsdk/role.go
+++ b/casdoorsdk/role.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -84,7 +83,7 @@ func (c *Client) GetPaginationRoles(p int, pageSize int, queryMap map[string]str
 
 func (c *Client) GetRole(name string) (*Role, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-role", queryMap)

--- a/casdoorsdk/session.go
+++ b/casdoorsdk/session.go
@@ -32,7 +32,8 @@ type Session struct {
 	Application string `xorm:"varchar(100) notnull pk" json:"application"`
 	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
 
-	SessionId []string `json:"sessionId"`
+	SessionId       []string `json:"sessionId"`
+	ExclusiveSignin bool     `xorm:"-"`
 }
 
 func (c *Client) GetSessions() ([]*Session, error) {

--- a/casdoorsdk/subscription.go
+++ b/casdoorsdk/subscription.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -100,7 +99,7 @@ func (c *Client) GetPaginationSubscriptions(p int, pageSize int, queryMap map[st
 
 func (c *Client) GetSubscription(name string) (*Subscription, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-subscription", queryMap)

--- a/casdoorsdk/syncer.go
+++ b/casdoorsdk/syncer.go
@@ -38,15 +38,21 @@ type Syncer struct {
 
 	Organization string `xorm:"varchar(100)" json:"organization"`
 	Type         string `xorm:"varchar(100)" json:"type"`
+	DatabaseType string `xorm:"varchar(100)" json:"databaseType"`
+	SslMode      string `xorm:"varchar(100)" json:"sslMode"`
+	SshType      string `xorm:"varchar(100)" json:"sshType"`
 
-	Host             string         `xorm:"varchar(100)" json:"host"`
-	Port             int            `json:"port"`
-	User             string         `xorm:"varchar(100)" json:"user"`
-	Password         string         `xorm:"varchar(100)" json:"password"`
-	DatabaseType     string         `xorm:"varchar(100)" json:"databaseType"`
-	Database         string         `xorm:"varchar(100)" json:"database"`
-	Table            string         `xorm:"varchar(100)" json:"table"`
-	TablePrimaryKey  string         `xorm:"varchar(100)" json:"tablePrimaryKey"`
+	Host        string `xorm:"varchar(100)" json:"host"`
+	Port        int    `json:"port"`
+	User        string `xorm:"varchar(100)" json:"user"`
+	Password    string `xorm:"varchar(150)" json:"password"`
+	SshHost     string `xorm:"varchar(100)" json:"sshHost"`
+	SshPort     int    `json:"sshPort"`
+	SshUser     string `xorm:"varchar(100)" json:"sshUser"`
+	SshPassword string `xorm:"varchar(150)" json:"sshPassword"`
+	Cert        string `xorm:"varchar(100)" json:"cert"`
+	Database    string `xorm:"varchar(100)" json:"database"`
+	Table       string `xorm:"varchar(100)" json:"table"`
 	TableColumns     []*TableColumn `xorm:"mediumtext" json:"tableColumns"`
 	AffiliationTable string         `xorm:"varchar(100)" json:"affiliationTable"`
 	AvatarBaseUrl    string         `xorm:"varchar(100)" json:"avatarBaseUrl"`

--- a/casdoorsdk/syncer.go
+++ b/casdoorsdk/syncer.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -42,17 +41,17 @@ type Syncer struct {
 	SslMode      string `xorm:"varchar(100)" json:"sslMode"`
 	SshType      string `xorm:"varchar(100)" json:"sshType"`
 
-	Host        string `xorm:"varchar(100)" json:"host"`
-	Port        int    `json:"port"`
-	User        string `xorm:"varchar(100)" json:"user"`
-	Password    string `xorm:"varchar(150)" json:"password"`
-	SshHost     string `xorm:"varchar(100)" json:"sshHost"`
-	SshPort     int    `json:"sshPort"`
-	SshUser     string `xorm:"varchar(100)" json:"sshUser"`
-	SshPassword string `xorm:"varchar(150)" json:"sshPassword"`
-	Cert        string `xorm:"varchar(100)" json:"cert"`
-	Database    string `xorm:"varchar(100)" json:"database"`
-	Table       string `xorm:"varchar(100)" json:"table"`
+	Host             string         `xorm:"varchar(100)" json:"host"`
+	Port             int            `json:"port"`
+	User             string         `xorm:"varchar(100)" json:"user"`
+	Password         string         `xorm:"varchar(150)" json:"password"`
+	SshHost          string         `xorm:"varchar(100)" json:"sshHost"`
+	SshPort          int            `json:"sshPort"`
+	SshUser          string         `xorm:"varchar(100)" json:"sshUser"`
+	SshPassword      string         `xorm:"varchar(150)" json:"sshPassword"`
+	Cert             string         `xorm:"varchar(100)" json:"cert"`
+	Database         string         `xorm:"varchar(100)" json:"database"`
+	Table            string         `xorm:"varchar(100)" json:"table"`
 	TableColumns     []*TableColumn `xorm:"mediumtext" json:"tableColumns"`
 	AffiliationTable string         `xorm:"varchar(100)" json:"affiliationTable"`
 	AvatarBaseUrl    string         `xorm:"varchar(100)" json:"avatarBaseUrl"`
@@ -112,7 +111,7 @@ func (c *Client) GetPaginationSyncers(p int, pageSize int, queryMap map[string]s
 
 func (c *Client) GetSyncer(name string) (*Syncer, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-syncer", queryMap)

--- a/casdoorsdk/token.go
+++ b/casdoorsdk/token.go
@@ -42,6 +42,7 @@ type Token struct {
 	CodeChallenge    string `xorm:"varchar(100)" json:"codeChallenge"`
 	CodeIsUsed       bool   `json:"codeIsUsed"`
 	CodeExpireIn     int64  `json:"codeExpireIn"`
+	Resource         string `xorm:"varchar(255)" json:"resource"` // RFC 8707 Resource Indicator
 }
 
 type IntrospectTokenResult struct {

--- a/casdoorsdk/token.go
+++ b/casdoorsdk/token.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -107,7 +106,7 @@ func (c *Client) GetPaginationTokens(p int, pageSize int, queryMap map[string]st
 
 func (c *Client) GetToken(name string) (*Token, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", name),
+		"id": getAdminId(name),
 	}
 
 	url := c.GetUrl("get-token", queryMap)

--- a/casdoorsdk/transaction.go
+++ b/casdoorsdk/transaction.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -93,7 +92,7 @@ func (c *Client) GetPaginationTransactions(p int, pageSize int, queryMap map[str
 
 func (c *Client) GetTransaction(name string) (*Transaction, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-transaction", queryMap)

--- a/casdoorsdk/user.go
+++ b/casdoorsdk/user.go
@@ -238,22 +238,22 @@ type User struct {
 	Custom10        string `xorm:"custom10 text" json:"custom10"`
 
 	// WebauthnCredentials []webauthn.Credential `xorm:"webauthnCredentials blob" json:"webauthnCredentials"`
-	PreferredMfaType    string      `xorm:"varchar(100)" json:"preferredMfaType"`
-	RecoveryCodes       []string    `xorm:"mediumtext" json:"recoveryCodes"`
-	TotpSecret          string      `xorm:"varchar(100)" json:"totpSecret"`
-	MfaPhoneEnabled     bool        `json:"mfaPhoneEnabled"`
-	MfaEmailEnabled     bool        `json:"mfaEmailEnabled"`
-	MfaRadiusEnabled    bool        `json:"mfaRadiusEnabled"`
-	MfaRadiusUsername   string      `xorm:"varchar(100)" json:"mfaRadiusUsername"`
-	MfaRadiusProvider   string      `xorm:"varchar(100)" json:"mfaRadiusProvider"`
-	MfaPushEnabled      bool        `json:"mfaPushEnabled"`
-	MfaPushReceiver     string      `xorm:"varchar(100)" json:"mfaPushReceiver"`
-	MfaPushProvider     string      `xorm:"varchar(100)" json:"mfaPushProvider"`
-	MultiFactorAuths    []*MfaProps `xorm:"-" json:"multiFactorAuths,omitempty"`
-	Invitation          string      `xorm:"varchar(100) index" json:"invitation"`
-	InvitationCode      string      `xorm:"varchar(100) index" json:"invitationCode"`
-	FaceIds             []*FaceId   `json:"faceIds"`
-	Cart                []ProductInfo `xorm:"mediumtext" json:"cart"`
+	PreferredMfaType  string        `xorm:"varchar(100)" json:"preferredMfaType"`
+	RecoveryCodes     []string      `xorm:"mediumtext" json:"recoveryCodes"`
+	TotpSecret        string        `xorm:"varchar(100)" json:"totpSecret"`
+	MfaPhoneEnabled   bool          `json:"mfaPhoneEnabled"`
+	MfaEmailEnabled   bool          `json:"mfaEmailEnabled"`
+	MfaRadiusEnabled  bool          `json:"mfaRadiusEnabled"`
+	MfaRadiusUsername string        `xorm:"varchar(100)" json:"mfaRadiusUsername"`
+	MfaRadiusProvider string        `xorm:"varchar(100)" json:"mfaRadiusProvider"`
+	MfaPushEnabled    bool          `json:"mfaPushEnabled"`
+	MfaPushReceiver   string        `xorm:"varchar(100)" json:"mfaPushReceiver"`
+	MfaPushProvider   string        `xorm:"varchar(100)" json:"mfaPushProvider"`
+	MultiFactorAuths  []*MfaProps   `xorm:"-" json:"multiFactorAuths,omitempty"`
+	Invitation        string        `xorm:"varchar(100) index" json:"invitation"`
+	InvitationCode    string        `xorm:"varchar(100) index" json:"invitationCode"`
+	FaceIds           []*FaceId     `json:"faceIds"`
+	Cart              []ProductInfo `xorm:"mediumtext" json:"cart"`
 
 	Ldap       string            `xorm:"ldap varchar(100)" json:"ldap"`
 	Properties map[string]string `json:"properties"`
@@ -381,7 +381,7 @@ func (c *Client) GetUserCount(isOnline string) (int, error) {
 
 func (c *Client) GetUser(name string) (*User, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-user", queryMap)

--- a/casdoorsdk/util.go
+++ b/casdoorsdk/util.go
@@ -38,7 +38,17 @@ func (c *Client) GetUrl(action string, queryMap map[string]string) string {
 }
 
 func (c *Client) GetId(name string) string {
+	if strings.Contains(name, "/") {
+		return name
+	}
 	return c.OrganizationName + "/" + name
+}
+
+func getAdminId(name string) string {
+	if strings.Contains(name, "/") {
+		return name
+	}
+	return "admin/" + name
 }
 
 func createFormFile(formData map[string][]byte) (string, io.Reader, error) {

--- a/casdoorsdk/util.go
+++ b/casdoorsdk/util.go
@@ -98,7 +98,7 @@ func (c *Client) DoGetResponse(url string) (*Response, error) {
 	}
 
 	if response.Status != "ok" {
-		return nil, fmt.Errorf(response.Msg)
+		return nil, errors.New(response.Msg)
 	}
 
 	return &response, nil
@@ -176,7 +176,7 @@ func (c *Client) DoPost(action string, queryMap map[string]string, postBytes []b
 	}
 
 	if response.Status != "ok" {
-		return nil, fmt.Errorf(response.Msg)
+		return nil, errors.New(response.Msg)
 	}
 
 	return &response, nil

--- a/casdoorsdk/util_modify.go
+++ b/casdoorsdk/util_modify.go
@@ -87,7 +87,9 @@ func (c *Client) modifyProvider(action string, provider *Provider, columns []str
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	provider.Owner = c.OrganizationName
+	if provider.Owner == "" {
+		provider.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(provider)
 	if err != nil {
 		return nil, false, err
@@ -112,7 +114,9 @@ func (c *Client) modifySession(action string, session *Session, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	session.Owner = c.OrganizationName
+	if session.Owner == "" {
+		session.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(session)
 	if err != nil {
 		return nil, false, err
@@ -199,7 +203,9 @@ func (c *Client) modifyPermission(action string, permission *Permission, columns
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	permission.Owner = c.OrganizationName
+	if permission.Owner == "" {
+		permission.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(permission)
 	if err != nil {
 		return nil, false, err
@@ -224,7 +230,9 @@ func (c *Client) modifyRole(action string, role *Role, columns []string) (*Respo
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	role.Owner = c.OrganizationName
+	if role.Owner == "" {
+		role.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(role)
 	if err != nil {
 		return nil, false, err
@@ -275,7 +283,9 @@ func (c *Client) modifyEnforcer(action string, enforcer *Enforcer, columns []str
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	enforcer.Owner = c.OrganizationName
+	if enforcer.Owner == "" {
+		enforcer.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(enforcer)
 	if err != nil {
 		return nil, false, err
@@ -291,7 +301,9 @@ func (c *Client) modifyEnforcer(action string, enforcer *Enforcer, columns []str
 
 // modifyPolicy is an encapsulation of cert CUD(Create, Update, Delete) operations.
 func (c *Client) modifyPolicy(action string, enforcer *Enforcer, policies []*CasbinRule, columns []string) (*Response, bool, error) {
-	enforcer.Owner = c.OrganizationName
+	if enforcer.Owner == "" {
+		enforcer.Owner = c.OrganizationName
+	}
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", enforcer.Owner, enforcer.Name),
 	}
@@ -331,7 +343,9 @@ func (c *Client) modifyGroup(action string, group *Group, columns []string) (*Re
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	group.Owner = c.OrganizationName
+	if group.Owner == "" {
+		group.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(group)
 	if err != nil {
 		return nil, false, err
@@ -356,7 +370,9 @@ func (c *Client) modifyAdapter(action string, adapter *Adapter, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	adapter.Owner = c.OrganizationName
+	if adapter.Owner == "" {
+		adapter.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(adapter)
 	if err != nil {
 		return nil, false, err
@@ -381,7 +397,9 @@ func (c *Client) modifyModel(action string, model *Model, columns []string) (*Re
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	model.Owner = c.OrganizationName
+	if model.Owner == "" {
+		model.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(model)
 	if err != nil {
 		return nil, false, err
@@ -406,7 +424,9 @@ func (c *Client) modifyProduct(action string, product *Product, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	product.Owner = c.OrganizationName
+	if product.Owner == "" {
+		product.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(product)
 	if err != nil {
 		return nil, false, err
@@ -431,7 +451,9 @@ func (c *Client) modifyOrder(action string, order *Order, columns []string) (*Re
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	order.Owner = c.OrganizationName
+	if order.Owner == "" {
+		order.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(order)
 	if err != nil {
 		return nil, false, err
@@ -456,7 +478,9 @@ func (c *Client) modifyPayment(action string, payment *Payment, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	payment.Owner = c.OrganizationName
+	if payment.Owner == "" {
+		payment.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(payment)
 	if err != nil {
 		return nil, false, err
@@ -481,7 +505,9 @@ func (c *Client) modifyPlan(action string, plan *Plan, columns []string) (*Respo
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	plan.Owner = c.OrganizationName
+	if plan.Owner == "" {
+		plan.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(plan)
 	if err != nil {
 		return nil, false, err
@@ -506,7 +532,9 @@ func (c *Client) modifyPricing(action string, pricing *Pricing, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	pricing.Owner = c.OrganizationName
+	if pricing.Owner == "" {
+		pricing.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(pricing)
 	if err != nil {
 		return nil, false, err
@@ -531,7 +559,9 @@ func (c *Client) modifySubscription(action string, subscription *Subscription, c
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	subscription.Owner = c.OrganizationName
+	if subscription.Owner == "" {
+		subscription.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(subscription)
 	if err != nil {
 		return nil, false, err
@@ -556,7 +586,9 @@ func (c *Client) modifySyncer(action string, syncer *Syncer, columns []string) (
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	syncer.Owner = c.OrganizationName
+	if syncer.Owner == "" {
+		syncer.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(syncer)
 	if err != nil {
 		return nil, false, err
@@ -592,7 +624,9 @@ func (c *Client) modifyTransactionWithDryRun(action string, transaction *Transac
 		queryMap["dryRun"] = "1"
 	}
 
-	transaction.Owner = c.OrganizationName
+	if transaction.Owner == "" {
+		transaction.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(transaction)
 	if err != nil {
 		return nil, false, err
@@ -617,7 +651,9 @@ func (c *Client) modifyWebhook(action string, webhook *Webhook, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	webhook.Owner = c.OrganizationName
+	if webhook.Owner == "" {
+		webhook.Owner = c.OrganizationName
+	}
 	postBytes, err := json.Marshal(webhook)
 	if err != nil {
 		return nil, false, err
@@ -634,7 +670,9 @@ func (c *Client) modifyWebhook(action string, webhook *Webhook, columns []string
 // modifyToken is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-token`, `update-token`, `delete-token`,
 func (c *Client) modifyToken(action string, token *Token, columns []string) (*Response, bool, error) {
-	token.Owner = "admin"
+	if token.Owner == "" {
+		token.Owner = "admin"
+	}
 
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", token.Owner, token.Name),

--- a/casdoorsdk/webhook.go
+++ b/casdoorsdk/webhook.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -94,7 +93,7 @@ func (c *Client) GetPaginationWebhooks(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetWebhook(name string) (*Webhook, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-webhook", queryMap)


### PR DESCRIPTION
Add new fields from upstream Casdoor to Application (Category, Type, Scopes, reverse proxy fields), Enforcer (ModelCfg), Group (ParentName, HaveChildren), Model (Description), Organization (AccountMenu, DcrPolicy), Provider (HttpHeaders, SslMode, EmailRegex, EnableProxy, EnablePkce), Record (Provider, Block), Session (ExclusiveSignin), Syncer (SSH/SSL fields), and Token (Resource).

Remove fields deleted upstream: ProviderItem.AlertType, Record.StatusCode/ExtendedUser, Syncer.TablePrimaryKey.

Replace fmt.Errorf with errors.New where no formatting is needed.

Fixes #232