### PR TITLE
feat: respect caller-provided owner instead of hardcoding defaults

### DIFF
--- a/casdoorsdk/adapter.go
+++ b/casdoorsdk/adapter.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -90,7 +89,7 @@ func (c *Client) GetPaginationAdapters(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetAdapter(name string) (*Adapter, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-adapter", queryMap)

--- a/casdoorsdk/adapter_test.go
+++ b/casdoorsdk/adapter_test.go
@@ -25,7 +25,7 @@ func TestAdapter(t *testing.T) {
 
 	// Add a new object
 	adapter := &Adapter{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		User:        name,

--- a/casdoorsdk/application.go
+++ b/casdoorsdk/application.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type ProviderItem struct {
@@ -199,7 +198,7 @@ func (c *Client) GetOrganizationApplications() ([]*Application, error) {
 
 func (c *Client) GetApplication(name string) (*Application, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", name),
+		"id": getAdminId(name),
 	}
 
 	url := c.GetUrl("get-application", queryMap)

--- a/casdoorsdk/cert.go
+++ b/casdoorsdk/cert.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // Cert has the same definition as https://github.com/casdoor/casdoor/blob/master/object/cert.go#L24
@@ -76,7 +75,7 @@ func (c *Client) GetCerts() ([]*Cert, error) {
 
 func (c *Client) GetCert(name string) (*Cert, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-cert", queryMap)

--- a/casdoorsdk/enforcer.go
+++ b/casdoorsdk/enforcer.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -84,7 +83,7 @@ func (c *Client) GetPaginationEnforcers(p int, pageSize int, queryMap map[string
 
 func (c *Client) GetEnforcer(name string) (*Enforcer, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-enforcer", queryMap)

--- a/casdoorsdk/enforcer_test.go
+++ b/casdoorsdk/enforcer_test.go
@@ -25,7 +25,7 @@ func TestEnforcer(t *testing.T) {
 
 	// Add a new object
 	enforcer := &Enforcer{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/group.go
+++ b/casdoorsdk/group.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -90,7 +89,7 @@ func (c *Client) GetPaginationGroups(p int, pageSize int, queryMap map[string]st
 
 func (c *Client) GetGroup(name string) (*Group, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-group", queryMap)

--- a/casdoorsdk/group_test.go
+++ b/casdoorsdk/group_test.go
@@ -25,7 +25,7 @@ func TestGroup(t *testing.T) {
 
 	// Add a new object
 	group := &Group{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/invitation.go
+++ b/casdoorsdk/invitation.go
@@ -92,7 +92,7 @@ func (c *Client) GetPaginationInvitations(p int, pageSize int, queryMap map[stri
 
 func (c *Client) GetInvitation(name string) (*Invitation, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-invitation", queryMap)

--- a/casdoorsdk/ldap.go
+++ b/casdoorsdk/ldap.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type Ldap struct {
@@ -98,7 +97,7 @@ func (c *Client) GetLdaps() ([]*Ldap, error) {
 
 func (c *Client) GetLdap(id string) (*Ldap, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", id),
+		"id": getAdminId(id),
 	}
 
 	url := c.GetUrl("get-ldap", queryMap)
@@ -133,7 +132,7 @@ func (c *Client) UpdateLdap(ldap *Ldap) (bool, error) {
 
 func (c *Client) GetLdapUsers(id string) (*LdapUsersResponse, error) {
 	url := c.GetUrl("get-ldap-users", map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, id),
+		"id": c.GetId(id),
 	})
 
 	bytes, err := c.DoGetBytes(url)
@@ -151,7 +150,7 @@ func (c *Client) GetLdapUsers(id string) (*LdapUsersResponse, error) {
 
 func (c *Client) SyncLdapUsers(id string, users []*LdapUser) (*SyncLdapUsersResponse, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, id),
+		"id": c.GetId(id),
 	}
 
 	postBytes, err := json.Marshal(users)

--- a/casdoorsdk/model.go
+++ b/casdoorsdk/model.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -91,7 +90,7 @@ func (c *Client) GetPaginationModels(p int, pageSize int, queryMap map[string]st
 
 func (c *Client) GetModel(name string) (*Model, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-model", queryMap)

--- a/casdoorsdk/order.go
+++ b/casdoorsdk/order.go
@@ -126,7 +126,7 @@ func (c *Client) GetUserOrders(userName string) ([]*Order, error) {
 
 func (c *Client) GetOrder(name string) (*Order, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-order", queryMap)
@@ -160,7 +160,7 @@ func (c *Client) DeleteOrder(order *Order) (bool, error) {
 
 func (c *Client) CancelOrder(name string) (bool, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	resp, err := c.DoPost("cancel-order", queryMap, []byte(""), false, false)

--- a/casdoorsdk/order_pay_test.go
+++ b/casdoorsdk/order_pay_test.go
@@ -20,7 +20,7 @@ func TestOrderPay(t *testing.T) {
 	InitConfig(TestCasdoorEndpoint, TestClientId, TestClientSecret, TestJwtPublicKey, TestCasdoorOrganization, TestCasdoorApplication)
 
 	name := getRandomName("OrderPayProduct")
-	owner := "admin"
+	owner := TestCasdoorOrganization
 
 	product := &Product{
 		Owner:       owner,
@@ -79,7 +79,7 @@ func TestBuyProduct(t *testing.T) {
 	InitConfig(TestCasdoorEndpoint, TestClientId, TestClientSecret, TestJwtPublicKey, TestCasdoorOrganization, TestCasdoorApplication)
 
 	name := getRandomName("BuyProduct")
-	owner := "admin"
+	owner := TestCasdoorOrganization
 
 	product := &Product{
 		Owner:       owner,

--- a/casdoorsdk/order_test.go
+++ b/casdoorsdk/order_test.go
@@ -21,7 +21,7 @@ func TestOrder(t *testing.T) {
 
 	productName := getRandomName("OrderProduct")
 	orderName := getRandomName("Order")
-	owner := "admin"
+	owner := TestCasdoorOrganization
 
 	product := &Product{
 		Owner:       owner,

--- a/casdoorsdk/organization.go
+++ b/casdoorsdk/organization.go
@@ -16,7 +16,6 @@ package casdoorsdk
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type AccountItem struct {
@@ -92,7 +91,7 @@ type Organization struct {
 
 func (c *Client) GetOrganization(name string) (*Organization, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", name),
+		"id": getAdminId(name),
 	}
 
 	url := c.GetUrl("get-organization", queryMap)

--- a/casdoorsdk/payment.go
+++ b/casdoorsdk/payment.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -106,7 +105,7 @@ func (c *Client) GetPaginationPayments(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetPayment(name string) (*Payment, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-payment", queryMap)

--- a/casdoorsdk/payment_test.go
+++ b/casdoorsdk/payment_test.go
@@ -27,7 +27,7 @@ func TestPayment(t *testing.T) {
 	// Add a new object
 	products := []string{"casbin"}
 	payment := &Payment{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/permission.go
+++ b/casdoorsdk/permission.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -69,7 +68,7 @@ func (c *Client) GetPermissions() ([]*Permission, error) {
 
 func (c *Client) GetPermissionsByRole(name string) ([]*Permission, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-permissions-by-role", queryMap)
@@ -115,7 +114,7 @@ func (c *Client) GetPaginationPermissions(p int, pageSize int, queryMap map[stri
 
 func (c *Client) GetPermission(name string) (*Permission, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-permission", queryMap)

--- a/casdoorsdk/plan.go
+++ b/casdoorsdk/plan.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -88,7 +87,7 @@ func (c *Client) GetPaginationPlans(p int, pageSize int, queryMap map[string]str
 
 func (c *Client) GetPlan(name string) (*Plan, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-plan", queryMap)

--- a/casdoorsdk/plan_test.go
+++ b/casdoorsdk/plan_test.go
@@ -25,7 +25,7 @@ func TestPlan(t *testing.T) {
 
 	// Add a new object
 	plan := &Plan{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/policy_test.go
+++ b/casdoorsdk/policy_test.go
@@ -23,7 +23,7 @@ func TestPolicy(t *testing.T) {
 
 	// Add a new object
 	enforcer := &Enforcer{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,
@@ -123,7 +123,7 @@ func TestGetFilteredPolicies(t *testing.T) {
 
 	// Add a new object
 	enforcer := &Enforcer{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/pricing.go
+++ b/casdoorsdk/pricing.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -89,7 +88,7 @@ func (c *Client) GetPaginationPricings(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetPricing(name string) (*Pricing, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-pricing", queryMap)

--- a/casdoorsdk/pricing_test.go
+++ b/casdoorsdk/pricing_test.go
@@ -25,7 +25,7 @@ func TestPricing(t *testing.T) {
 
 	// Add a new object
 	pricing := &Pricing{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/product.go
+++ b/casdoorsdk/product.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -94,7 +93,7 @@ func (c *Client) GetPaginationProducts(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetProduct(name string) (*Product, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-product", queryMap)

--- a/casdoorsdk/product_test.go
+++ b/casdoorsdk/product_test.go
@@ -22,7 +22,7 @@ func TestProduct(t *testing.T) {
 	InitConfig(TestCasdoorEndpoint, TestClientId, TestClientSecret, TestJwtPublicKey, TestCasdoorOrganization, TestCasdoorApplication)
 
 	name := getRandomName("Product")
-	owner := "admin"
+	owner := TestCasdoorOrganization
 
 	// Add a new object
 	product := &Product{

--- a/casdoorsdk/provider.go
+++ b/casdoorsdk/provider.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -91,7 +90,7 @@ func (c *Client) GetProviders() ([]*Provider, error) {
 
 func (c *Client) GetProvider(name string) (*Provider, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-provider", queryMap)

--- a/casdoorsdk/record.go
+++ b/casdoorsdk/record.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -36,9 +35,9 @@ type Record struct {
 	Action       string `xorm:"varchar(1000)" json:"action"`
 	Language     string `xorm:"varchar(100)" json:"language"`
 
-	StatusCode   int    `json:"statusCode"`
-	Response     string `xorm:"mediumtext" json:"response"`
-	Object       string `xorm:"mediumtext" json:"object"`
+	StatusCode int    `json:"statusCode"`
+	Response   string `xorm:"mediumtext" json:"response"`
+	Object     string `xorm:"mediumtext" json:"object"`
 
 	IsTriggered bool `json:"isTriggered"`
 }
@@ -91,7 +90,7 @@ func (c *Client) GetPaginationRecords(p int, pageSize int, queryMap map[string]s
 
 func (c *Client) GetRecord(name string) (*Record, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-record", queryMap)

--- a/casdoorsdk/role.go
+++ b/casdoorsdk/role.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -84,7 +83,7 @@ func (c *Client) GetPaginationRoles(p int, pageSize int, queryMap map[string]str
 
 func (c *Client) GetRole(name string) (*Role, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-role", queryMap)

--- a/casdoorsdk/role_test.go
+++ b/casdoorsdk/role_test.go
@@ -25,7 +25,7 @@ func TestRole(t *testing.T) {
 
 	// Add a new object
 	role := &Role{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/subscription.go
+++ b/casdoorsdk/subscription.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -100,7 +99,7 @@ func (c *Client) GetPaginationSubscriptions(p int, pageSize int, queryMap map[st
 
 func (c *Client) GetSubscription(name string) (*Subscription, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-subscription", queryMap)

--- a/casdoorsdk/subscription_test.go
+++ b/casdoorsdk/subscription_test.go
@@ -25,7 +25,7 @@ func TestSubscription(t *testing.T) {
 
 	// Add a new object
 	subscription := &Subscription{
-		Owner:       "admin",
+		Owner:       TestCasdoorOrganization,
 		Name:        name,
 		CreatedTime: GetCurrentTime(),
 		DisplayName: name,

--- a/casdoorsdk/syncer.go
+++ b/casdoorsdk/syncer.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -106,7 +105,7 @@ func (c *Client) GetPaginationSyncers(p int, pageSize int, queryMap map[string]s
 
 func (c *Client) GetSyncer(name string) (*Syncer, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-syncer", queryMap)

--- a/casdoorsdk/syncer_test.go
+++ b/casdoorsdk/syncer_test.go
@@ -25,7 +25,7 @@ func TestSyncer(t *testing.T) {
 
 	// Add a new object
 	syncer := &Syncer{
-		Owner:        "admin",
+		Owner:        TestCasdoorOrganization,
 		Name:         name,
 		CreatedTime:  GetCurrentTime(),
 		Organization: "casbin",

--- a/casdoorsdk/token.go
+++ b/casdoorsdk/token.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -106,7 +105,7 @@ func (c *Client) GetPaginationTokens(p int, pageSize int, queryMap map[string]st
 
 func (c *Client) GetToken(name string) (*Token, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", "admin", name),
+		"id": getAdminId(name),
 	}
 
 	url := c.GetUrl("get-token", queryMap)

--- a/casdoorsdk/transaction.go
+++ b/casdoorsdk/transaction.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -93,7 +92,7 @@ func (c *Client) GetPaginationTransactions(p int, pageSize int, queryMap map[str
 
 func (c *Client) GetTransaction(name string) (*Transaction, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-transaction", queryMap)

--- a/casdoorsdk/user.go
+++ b/casdoorsdk/user.go
@@ -238,22 +238,22 @@ type User struct {
 	Custom10        string `xorm:"custom10 text" json:"custom10"`
 
 	// WebauthnCredentials []webauthn.Credential `xorm:"webauthnCredentials blob" json:"webauthnCredentials"`
-	PreferredMfaType    string      `xorm:"varchar(100)" json:"preferredMfaType"`
-	RecoveryCodes       []string    `xorm:"mediumtext" json:"recoveryCodes"`
-	TotpSecret          string      `xorm:"varchar(100)" json:"totpSecret"`
-	MfaPhoneEnabled     bool        `json:"mfaPhoneEnabled"`
-	MfaEmailEnabled     bool        `json:"mfaEmailEnabled"`
-	MfaRadiusEnabled    bool        `json:"mfaRadiusEnabled"`
-	MfaRadiusUsername   string      `xorm:"varchar(100)" json:"mfaRadiusUsername"`
-	MfaRadiusProvider   string      `xorm:"varchar(100)" json:"mfaRadiusProvider"`
-	MfaPushEnabled      bool        `json:"mfaPushEnabled"`
-	MfaPushReceiver     string      `xorm:"varchar(100)" json:"mfaPushReceiver"`
-	MfaPushProvider     string      `xorm:"varchar(100)" json:"mfaPushProvider"`
-	MultiFactorAuths    []*MfaProps `xorm:"-" json:"multiFactorAuths,omitempty"`
-	Invitation          string      `xorm:"varchar(100) index" json:"invitation"`
-	InvitationCode      string      `xorm:"varchar(100) index" json:"invitationCode"`
-	FaceIds             []*FaceId   `json:"faceIds"`
-	Cart                []ProductInfo `xorm:"mediumtext" json:"cart"`
+	PreferredMfaType  string        `xorm:"varchar(100)" json:"preferredMfaType"`
+	RecoveryCodes     []string      `xorm:"mediumtext" json:"recoveryCodes"`
+	TotpSecret        string        `xorm:"varchar(100)" json:"totpSecret"`
+	MfaPhoneEnabled   bool          `json:"mfaPhoneEnabled"`
+	MfaEmailEnabled   bool          `json:"mfaEmailEnabled"`
+	MfaRadiusEnabled  bool          `json:"mfaRadiusEnabled"`
+	MfaRadiusUsername string        `xorm:"varchar(100)" json:"mfaRadiusUsername"`
+	MfaRadiusProvider string        `xorm:"varchar(100)" json:"mfaRadiusProvider"`
+	MfaPushEnabled    bool          `json:"mfaPushEnabled"`
+	MfaPushReceiver   string        `xorm:"varchar(100)" json:"mfaPushReceiver"`
+	MfaPushProvider   string        `xorm:"varchar(100)" json:"mfaPushProvider"`
+	MultiFactorAuths  []*MfaProps   `xorm:"-" json:"multiFactorAuths,omitempty"`
+	Invitation        string        `xorm:"varchar(100) index" json:"invitation"`
+	InvitationCode    string        `xorm:"varchar(100) index" json:"invitationCode"`
+	FaceIds           []*FaceId     `json:"faceIds"`
+	Cart              []ProductInfo `xorm:"mediumtext" json:"cart"`
 
 	Ldap       string            `xorm:"ldap varchar(100)" json:"ldap"`
 	Properties map[string]string `json:"properties"`
@@ -381,7 +381,7 @@ func (c *Client) GetUserCount(isOnline string) (int, error) {
 
 func (c *Client) GetUser(name string) (*User, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-user", queryMap)

--- a/casdoorsdk/util.go
+++ b/casdoorsdk/util.go
@@ -37,8 +37,30 @@ func (c *Client) GetUrl(action string, queryMap map[string]string) string {
 	return fmt.Sprintf("%s/api/%s?%s", c.Endpoint, action, query)
 }
 
+// GetId builds a Casdoor resource ID of the form "owner/name" for resources
+// scoped to an organization (roles, groups, adapters, certs, etc.). If the
+// caller already passes a qualified "owner/name" string it is returned as-is,
+// otherwise the client's configured organization is used as the owner.
 func (c *Client) GetId(name string) string {
+	if strings.Contains(name, "/") {
+		return name
+	}
 	return c.OrganizationName + "/" + name
+}
+
+// getAdminId builds a Casdoor resource ID with "admin" as the owner. It is used
+// for resource types (organizations, applications, tokens, LDAP configs) whose
+// owner is conventionally "admin" rather than a tenant organization: the
+// Casdoor server defaults their owner to "admin" on create and the default seed
+// data stores them that way, so looking them up under "admin" is the only thing
+// that works out of the box. The server does not strictly enforce this — a
+// caller that has deliberately created such a resource under a different owner
+// can pass a qualified "owner/name" string and it will be returned as-is.
+func getAdminId(name string) string {
+	if strings.Contains(name, "/") {
+		return name
+	}
+	return "admin/" + name
 }
 
 func createFormFile(formData map[string][]byte) (string, io.Reader, error) {

--- a/casdoorsdk/util_modify.go
+++ b/casdoorsdk/util_modify.go
@@ -79,6 +79,10 @@ func (c *Client) modifyApplication(action string, application *Application, colu
 // modifyProvider is an encapsulation of permission CUD(Create, Update, Delete) operations.
 // possible actions are `add-provider`, `update-provider`, `delete-provider`,
 func (c *Client) modifyProvider(action string, provider *Provider, columns []string) (*Response, bool, error) {
+	if provider.Owner == "" {
+		provider.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", provider.Owner, provider.Name),
 	}
@@ -87,7 +91,6 @@ func (c *Client) modifyProvider(action string, provider *Provider, columns []str
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	provider.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(provider)
 	if err != nil {
 		return nil, false, err
@@ -104,6 +107,10 @@ func (c *Client) modifyProvider(action string, provider *Provider, columns []str
 // modifySession is an encapsulation of permission CUD(Create, Update, Delete) operations.
 // possible actions are `add-session`, `update-session`, `delete-session`,
 func (c *Client) modifySession(action string, session *Session, columns []string) (*Response, bool, error) {
+	if session.Owner == "" {
+		session.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", session.Owner, session.Name),
 	}
@@ -112,7 +119,6 @@ func (c *Client) modifySession(action string, session *Session, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	session.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(session)
 	if err != nil {
 		return nil, false, err
@@ -191,6 +197,10 @@ func (c *Client) modifyUserByUserId(action string, owner string, userId string, 
 // modifyPermission is an encapsulation of permission CUD(Create, Update, Delete) operations.
 // possible actions are `add-permission`, `update-permission`, `delete-permission`,
 func (c *Client) modifyPermission(action string, permission *Permission, columns []string) (*Response, bool, error) {
+	if permission.Owner == "" {
+		permission.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", permission.Owner, permission.Name),
 	}
@@ -199,7 +209,6 @@ func (c *Client) modifyPermission(action string, permission *Permission, columns
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	permission.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(permission)
 	if err != nil {
 		return nil, false, err
@@ -216,6 +225,10 @@ func (c *Client) modifyPermission(action string, permission *Permission, columns
 // modifyRole is an encapsulation of role CUD(Create, Update, Delete) operations.
 // possible actions are `add-role`, `update-role`, `delete-role`,
 func (c *Client) modifyRole(action string, role *Role, columns []string) (*Response, bool, error) {
+	if role.Owner == "" {
+		role.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", role.Owner, role.Name),
 	}
@@ -224,7 +237,6 @@ func (c *Client) modifyRole(action string, role *Role, columns []string) (*Respo
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	role.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(role)
 	if err != nil {
 		return nil, false, err
@@ -241,6 +253,10 @@ func (c *Client) modifyRole(action string, role *Role, columns []string) (*Respo
 // modifyCert is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-cert`, `update-cert`, `delete-cert`,
 func (c *Client) modifyCert(action string, cert *Cert, columns []string) (*Response, bool, error) {
+	if cert.Owner == "" {
+		cert.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", cert.Owner, cert.Name),
 	}
@@ -249,9 +265,6 @@ func (c *Client) modifyCert(action string, cert *Cert, columns []string) (*Respo
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	if cert.Owner == "" {
-		cert.Owner = c.OrganizationName
-	}
 	postBytes, err := json.Marshal(cert)
 	if err != nil {
 		return nil, false, err
@@ -267,6 +280,10 @@ func (c *Client) modifyCert(action string, cert *Cert, columns []string) (*Respo
 
 // modifyEnforcer is an encapsulation of cert CUD(Create, Update, Delete) operations.
 func (c *Client) modifyEnforcer(action string, enforcer *Enforcer, columns []string) (*Response, bool, error) {
+	if enforcer.Owner == "" {
+		enforcer.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", enforcer.Owner, enforcer.Name),
 	}
@@ -275,7 +292,6 @@ func (c *Client) modifyEnforcer(action string, enforcer *Enforcer, columns []str
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	enforcer.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(enforcer)
 	if err != nil {
 		return nil, false, err
@@ -291,7 +307,9 @@ func (c *Client) modifyEnforcer(action string, enforcer *Enforcer, columns []str
 
 // modifyPolicy is an encapsulation of cert CUD(Create, Update, Delete) operations.
 func (c *Client) modifyPolicy(action string, enforcer *Enforcer, policies []*CasbinRule, columns []string) (*Response, bool, error) {
-	enforcer.Owner = c.OrganizationName
+	if enforcer.Owner == "" {
+		enforcer.Owner = c.OrganizationName
+	}
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", enforcer.Owner, enforcer.Name),
 	}
@@ -323,6 +341,10 @@ func (c *Client) modifyPolicy(action string, enforcer *Enforcer, policies []*Cas
 // modifyEnforcer is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-group`, `update-group`, `delete-group`,
 func (c *Client) modifyGroup(action string, group *Group, columns []string) (*Response, bool, error) {
+	if group.Owner == "" {
+		group.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", group.Owner, group.Name),
 	}
@@ -331,7 +353,6 @@ func (c *Client) modifyGroup(action string, group *Group, columns []string) (*Re
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	group.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(group)
 	if err != nil {
 		return nil, false, err
@@ -348,6 +369,10 @@ func (c *Client) modifyGroup(action string, group *Group, columns []string) (*Re
 // modifyAdapter is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-adapter`, `update-adapter`, `delete-adapter`,
 func (c *Client) modifyAdapter(action string, adapter *Adapter, columns []string) (*Response, bool, error) {
+	if adapter.Owner == "" {
+		adapter.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", adapter.Owner, adapter.Name),
 	}
@@ -356,7 +381,6 @@ func (c *Client) modifyAdapter(action string, adapter *Adapter, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	adapter.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(adapter)
 	if err != nil {
 		return nil, false, err
@@ -373,6 +397,10 @@ func (c *Client) modifyAdapter(action string, adapter *Adapter, columns []string
 // modifyModel is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-model`, `update-model`, `delete-model`,
 func (c *Client) modifyModel(action string, model *Model, columns []string) (*Response, bool, error) {
+	if model.Owner == "" {
+		model.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", model.Owner, model.Name),
 	}
@@ -381,7 +409,6 @@ func (c *Client) modifyModel(action string, model *Model, columns []string) (*Re
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	model.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(model)
 	if err != nil {
 		return nil, false, err
@@ -398,6 +425,10 @@ func (c *Client) modifyModel(action string, model *Model, columns []string) (*Re
 // modifyProduct is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-product`, `update-product`, `delete-product`,
 func (c *Client) modifyProduct(action string, product *Product, columns []string) (*Response, bool, error) {
+	if product.Owner == "" {
+		product.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", product.Owner, product.Name),
 	}
@@ -406,7 +437,6 @@ func (c *Client) modifyProduct(action string, product *Product, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	product.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(product)
 	if err != nil {
 		return nil, false, err
@@ -423,6 +453,10 @@ func (c *Client) modifyProduct(action string, product *Product, columns []string
 // modifyOrder is an encapsulation of order CUD(Create, Update, Delete) operations.
 // possible actions are `add-order`, `update-order`, `delete-order`,
 func (c *Client) modifyOrder(action string, order *Order, columns []string) (*Response, bool, error) {
+	if order.Owner == "" {
+		order.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", order.Owner, order.Name),
 	}
@@ -431,7 +465,6 @@ func (c *Client) modifyOrder(action string, order *Order, columns []string) (*Re
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	order.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(order)
 	if err != nil {
 		return nil, false, err
@@ -448,6 +481,10 @@ func (c *Client) modifyOrder(action string, order *Order, columns []string) (*Re
 // modifyPayment is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-payment`, `update-payment`, `delete-payment`,
 func (c *Client) modifyPayment(action string, payment *Payment, columns []string) (*Response, bool, error) {
+	if payment.Owner == "" {
+		payment.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", payment.Owner, payment.Name),
 	}
@@ -456,7 +493,6 @@ func (c *Client) modifyPayment(action string, payment *Payment, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	payment.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(payment)
 	if err != nil {
 		return nil, false, err
@@ -473,6 +509,10 @@ func (c *Client) modifyPayment(action string, payment *Payment, columns []string
 // modifyPlan is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-plan`, `update-plan`, `delete-plan`,
 func (c *Client) modifyPlan(action string, plan *Plan, columns []string) (*Response, bool, error) {
+	if plan.Owner == "" {
+		plan.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", plan.Owner, plan.Name),
 	}
@@ -481,7 +521,6 @@ func (c *Client) modifyPlan(action string, plan *Plan, columns []string) (*Respo
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	plan.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(plan)
 	if err != nil {
 		return nil, false, err
@@ -498,6 +537,10 @@ func (c *Client) modifyPlan(action string, plan *Plan, columns []string) (*Respo
 // modifyPricing is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-pricing`, `update-pricing`, `delete-pricing`,
 func (c *Client) modifyPricing(action string, pricing *Pricing, columns []string) (*Response, bool, error) {
+	if pricing.Owner == "" {
+		pricing.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", pricing.Owner, pricing.Name),
 	}
@@ -506,7 +549,6 @@ func (c *Client) modifyPricing(action string, pricing *Pricing, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	pricing.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(pricing)
 	if err != nil {
 		return nil, false, err
@@ -523,6 +565,10 @@ func (c *Client) modifyPricing(action string, pricing *Pricing, columns []string
 // modifySubscription is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-subscription`, `update-subscription`, `delete-subscription`,
 func (c *Client) modifySubscription(action string, subscription *Subscription, columns []string) (*Response, bool, error) {
+	if subscription.Owner == "" {
+		subscription.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", subscription.Owner, subscription.Name),
 	}
@@ -531,7 +577,6 @@ func (c *Client) modifySubscription(action string, subscription *Subscription, c
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	subscription.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(subscription)
 	if err != nil {
 		return nil, false, err
@@ -548,6 +593,10 @@ func (c *Client) modifySubscription(action string, subscription *Subscription, c
 // modifySyner is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-syncer`, `update-syncer`, `delete-syncer`,
 func (c *Client) modifySyncer(action string, syncer *Syncer, columns []string) (*Response, bool, error) {
+	if syncer.Owner == "" {
+		syncer.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", syncer.Owner, syncer.Name),
 	}
@@ -556,7 +605,6 @@ func (c *Client) modifySyncer(action string, syncer *Syncer, columns []string) (
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	syncer.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(syncer)
 	if err != nil {
 		return nil, false, err
@@ -580,6 +628,10 @@ func (c *Client) modifyTransaction(action string, transaction *Transaction, colu
 // possible actions are `add-transaction`, `update-transaction`, `delete-transaction`.
 // dryrun parameter is only applicable for `add-transaction` action.
 func (c *Client) modifyTransactionWithDryRun(action string, transaction *Transaction, columns []string, dryrun bool) (*Response, bool, error) {
+	if transaction.Owner == "" {
+		transaction.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", transaction.Owner, transaction.Name),
 	}
@@ -592,7 +644,6 @@ func (c *Client) modifyTransactionWithDryRun(action string, transaction *Transac
 		queryMap["dryRun"] = "1"
 	}
 
-	transaction.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(transaction)
 	if err != nil {
 		return nil, false, err
@@ -609,6 +660,10 @@ func (c *Client) modifyTransactionWithDryRun(action string, transaction *Transac
 // modifyWebhook is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-webhook`, `update-webhook`, `delete-webhook`,
 func (c *Client) modifyWebhook(action string, webhook *Webhook, columns []string) (*Response, bool, error) {
+	if webhook.Owner == "" {
+		webhook.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", webhook.Owner, webhook.Name),
 	}
@@ -617,7 +672,6 @@ func (c *Client) modifyWebhook(action string, webhook *Webhook, columns []string
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	webhook.Owner = c.OrganizationName
 	postBytes, err := json.Marshal(webhook)
 	if err != nil {
 		return nil, false, err
@@ -634,7 +688,9 @@ func (c *Client) modifyWebhook(action string, webhook *Webhook, columns []string
 // modifyToken is an encapsulation of cert CUD(Create, Update, Delete) operations.
 // possible actions are `add-token`, `update-token`, `delete-token`,
 func (c *Client) modifyToken(action string, token *Token, columns []string) (*Response, bool, error) {
-	token.Owner = "admin"
+	if token.Owner == "" {
+		token.Owner = "admin"
+	}
 
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", token.Owner, token.Name),
@@ -688,6 +744,10 @@ func (c *Client) modifyLdap(action string, ldap *Ldap, columns []string) (*Respo
 // modifyInvitation is an encapsulation of invitation CUD(Create, Update, Delete) operations.
 // possible actions are `add-invitation`, `update-invitation`, `delete-invitation`,
 func (c *Client) modifyInvitation(action string, invitation *Invitation, columns []string) (*Response, bool, error) {
+	if invitation.Owner == "" {
+		invitation.Owner = c.OrganizationName
+	}
+
 	queryMap := map[string]string{
 		"id": fmt.Sprintf("%s/%s", invitation.Owner, invitation.Name),
 	}
@@ -696,9 +756,6 @@ func (c *Client) modifyInvitation(action string, invitation *Invitation, columns
 		queryMap["columns"] = strings.Join(columns, ",")
 	}
 
-	if invitation.Owner == "" {
-		invitation.Owner = c.OrganizationName
-	}
 	postBytes, err := json.Marshal(invitation)
 	if err != nil {
 		return nil, false, err

--- a/casdoorsdk/webhook.go
+++ b/casdoorsdk/webhook.go
@@ -17,7 +17,6 @@ package casdoorsdk
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -94,7 +93,7 @@ func (c *Client) GetPaginationWebhooks(p int, pageSize int, queryMap map[string]
 
 func (c *Client) GetWebhook(name string) (*Webhook, error) {
 	queryMap := map[string]string{
-		"id": fmt.Sprintf("%s/%s", c.OrganizationName, name),
+		"id": c.GetId(name),
 	}
 
 	url := c.GetUrl("get-webhook", queryMap)


### PR DESCRIPTION
GetX methods now pass through owner/name IDs as-is when the name already contains a slash, instead of always prepending the client's default organization. modifyX methods now only set Owner when the caller left it empty, preserving explicitly set owners.

This allows callers (like Terraform providers) to operate on resources in organizations other than the SDK client's configured default.

Fixes #236