### PR TITLE
feat: add back BuyProduct API for compatibility

### DIFF
--- a/casdoorsdk/order_pay.go
+++ b/casdoorsdk/order_pay.go
@@ -80,3 +80,10 @@ func (c *Client) PayOrder(orderName string, providerName string) (*Payment, erro
 
 	return &payment, nil
 }
+
+func (c *Client) BuyProduct(name string, providerName string, userName string) (*Order, error) {
+	return c.PlaceOrder([]ProductInfo{{
+		Name:     name,
+		Quantity: 1,
+	}}, userName)
+}

--- a/casdoorsdk/order_pay_global.go
+++ b/casdoorsdk/order_pay_global.go
@@ -21,3 +21,7 @@ func PlaceOrder(productInfos []ProductInfo, userName string) (*Order, error) {
 func PayOrder(orderName string, providerName string) (*Payment, error) {
 	return globalClient.PayOrder(orderName, providerName)
 }
+
+func BuyProduct(name string, providerName string, userName string) (*Order, error) {
+	return globalClient.BuyProduct(name, providerName, userName)
+}

--- a/casdoorsdk/order_pay_test.go
+++ b/casdoorsdk/order_pay_test.go
@@ -74,3 +74,57 @@ func TestOrderPay(t *testing.T) {
 		t.Fatalf("Failed to delete product, it's still retrievable")
 	}
 }
+
+func TestBuyProduct(t *testing.T) {
+	InitConfig(TestCasdoorEndpoint, TestClientId, TestClientSecret, TestJwtPublicKey, TestCasdoorOrganization, TestCasdoorApplication)
+
+	name := getRandomName("BuyProduct")
+	owner := "admin"
+
+	product := &Product{
+		Owner:       owner,
+		Name:        name,
+		CreatedTime: GetCurrentTime(),
+		DisplayName: name,
+
+		Image:       "https://cdn.casbin.org/img/casdoor-logo_1185x256.png",
+		Description: "Casdoor Website",
+		Tag:         "auto_created_product_for_plan",
+
+		Quantity:  999,
+		Sold:      0,
+		State:     "Published",
+		Providers: []string{"provider_payment_dummy"},
+		Currency:  "USD",
+	}
+	_, err := AddProduct(product)
+	if err != nil {
+		t.Fatalf("Failed to add product: %v", err)
+	}
+
+	order, err := BuyProduct(name, "provider_payment_dummy", "admin")
+	if err != nil {
+		t.Fatalf("Failed to buy product: %v", err)
+	}
+	if order == nil {
+		t.Fatalf("Failed to buy product: nil response")
+	}
+
+	payment, err := PayOrder(order.Name, "provider_payment_dummy")
+	if err != nil {
+		t.Fatalf("Failed to pay order: %v", err)
+	}
+	if payment == nil {
+		t.Fatalf("Failed to pay order: nil response")
+	}
+
+	_, err = DeleteProduct(product)
+	if err != nil {
+		t.Fatalf("Failed to delete product: %v", err)
+	}
+
+	deletedProduct, err := GetProduct(name)
+	if err != nil || deletedProduct != nil {
+		t.Fatalf("Failed to delete product, it's still retrievable")
+	}
+}


### PR DESCRIPTION
fix: https://github.com/casdoor/casdoor/issues/5348

Changes
1. add BuyProduct method back to the client API
2. implement BuyProduct as a thin convenience layer that creates a single-item ProductInfo and delegates to PlaceOrder
3. add an integration-style TestBuyProduct following the same pattern as TestOrderPay