### PR TITLE
feat: add SendNotification API

### DIFF
--- a/casdoorsdk/notification.go
+++ b/casdoorsdk/notification.go
@@ -17,12 +17,14 @@ package casdoorsdk
 import "encoding/json"
 
 type notificationForm struct {
-	Content string `json:"content"`
+	Content   string `json:"content"`
+	Recipient string `json:"recipient,omitempty"`
 }
 
-func (c *Client) SendNotification(content string) error {
+func (c *Client) SendNotification(content string, recipient string) error {
 	form := notificationForm{
-		Content: content,
+		Content:   content,
+		Recipient: recipient,
 	}
 	postBytes, err := json.Marshal(form)
 	if err != nil {

--- a/casdoorsdk/notification.go
+++ b/casdoorsdk/notification.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package casdoorsdk
+
+import "encoding/json"
+
+type notificationForm struct {
+	Content string `json:"content"`
+}
+
+func (c *Client) SendNotification(content string) error {
+	form := notificationForm{
+		Content: content,
+	}
+	postBytes, err := json.Marshal(form)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.DoPost("send-notification", nil, postBytes, false, false)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/casdoorsdk/notification_global.go
+++ b/casdoorsdk/notification_global.go
@@ -14,6 +14,6 @@
 
 package casdoorsdk
 
-func SendNotification(content string) error {
-	return globalClient.SendNotification(content)
+func SendNotification(content string, recipient string) error {
+	return globalClient.SendNotification(content, recipient)
 }

--- a/casdoorsdk/notification_global.go
+++ b/casdoorsdk/notification_global.go
@@ -1,0 +1,19 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package casdoorsdk
+
+func SendNotification(content string) error {
+	return globalClient.SendNotification(content)
+}


### PR DESCRIPTION
for: https://github.com/the-open-agent/openagent/issues/2432

## Summary

Add `SendNotification(content, recipient)` to the Go SDK.

This wraps Casdoor's `/api/send-notification` service API and sends:

```json
{
  "content": "...",
  "recipient": "..."
}