### PR TITLE
fix: stabilize token and policy tests

### DIFF
--- a/casdoorsdk/policy_test.go
+++ b/casdoorsdk/policy_test.go
@@ -14,7 +14,10 @@
 
 package casdoorsdk
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestPolicy(t *testing.T) {
 	InitConfig(TestCasdoorEndpoint, TestClientId, TestClientSecret, TestJwtPublicKey, TestCasdoorOrganization, TestCasdoorApplication)
@@ -31,17 +34,24 @@ func TestPolicy(t *testing.T) {
 		Adapter:     "built-in/user-adapter-built-in",
 		Description: "Casdoor Website",
 	}
-	_, err := AddEnforcer(enforcer)
+	affected, err := AddEnforcer(enforcer)
 	if err != nil {
 		t.Fatalf("Failed to add object: %v", err)
 	}
+	if !affected {
+		t.Fatalf("Failed to add object")
+	}
+	defer DeleteEnforcer(enforcer)
+
+	oldPolicyValue := getRandomName("PolicyOld")
+	newPolicyValue := getRandomName("PolicyNew")
 
 	//Add a new policy
 	policy := &CasbinRule{
 		Ptype: "p",
 		V0:    "1",
 		V1:    "2",
-		V2:    "4",
+		V2:    oldPolicyValue,
 	}
 	_, err = AddPolicy(enforcer, policy)
 	if err != nil {
@@ -49,16 +59,9 @@ func TestPolicy(t *testing.T) {
 	}
 	//
 	// Get all objects, check if our added object is inside the list
-	Policies, err := GetPolicies(name, "")
+	found, err := waitForPolicy(name, "p", oldPolicyValue, true)
 	if err != nil {
 		t.Fatalf("Failed to get objects: %v", err)
-	}
-	found := false
-	for _, item := range Policies {
-		if item.Ptype == "p" && item.V2 == "4" {
-			found = true
-			break
-		}
 	}
 	if !found {
 		t.Fatalf("Added object not found in list")
@@ -68,7 +71,7 @@ func TestPolicy(t *testing.T) {
 		Ptype: "p",
 		V0:    "1",
 		V1:    "2",
-		V2:    "5",
+		V2:    newPolicyValue,
 	}
 
 	// Update the object
@@ -78,16 +81,9 @@ func TestPolicy(t *testing.T) {
 	}
 
 	// Validate the update
-	Policies, err = GetPolicies(name, "")
+	found, err = waitForPolicy(name, "p", newPolicyValue, true)
 	if err != nil {
 		t.Fatalf("Failed to get updated object: %v", err)
-	}
-	found = false
-	for _, item := range Policies {
-		if item.Ptype == "p" && item.V2 == "5" {
-			found = true
-			break
-		}
 	}
 	if !found {
 		t.Fatalf("Update object not found in list")
@@ -100,20 +96,35 @@ func TestPolicy(t *testing.T) {
 	}
 
 	// Validate the deletion
-	Policies, err = GetPolicies(name, "")
+	found, err = waitForPolicy(name, "p", newPolicyValue, false)
 	if err != nil {
 		t.Fatalf("Failed to get updated object: %v", err)
 	}
-	found = false
-	for _, item := range Policies {
-		if item.Ptype == "p" && item.V2 == "3" {
-			found = true
-			break
-		}
-	}
-	if found {
+	if !found {
 		t.Fatalf("Delete object found in list")
 	}
+}
+
+func waitForPolicy(name string, ptype string, v2 string, expected bool) (bool, error) {
+	var err error
+	for i := 0; i < 5; i++ {
+		var policies []*CasbinRule
+		policies, err = GetPolicies(name, "")
+		if err == nil && hasPolicy(policies, ptype, v2) == expected {
+			return true, nil
+		}
+		time.Sleep(time.Second)
+	}
+	return false, err
+}
+
+func hasPolicy(policies []*CasbinRule, ptype string, v2 string) bool {
+	for _, item := range policies {
+		if item.Ptype == ptype && item.V2 == v2 {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGetFilteredPolicies(t *testing.T) {

--- a/casdoorsdk/token_test.go
+++ b/casdoorsdk/token_test.go
@@ -15,7 +15,9 @@
 package casdoorsdk
 
 import (
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestToken(t *testing.T) {
@@ -80,14 +82,36 @@ func TestToken(t *testing.T) {
 	}
 
 	// Delete the object
-	_, err = DeleteToken(token)
+	affected, err := DeleteToken(token)
 	if err != nil {
 		t.Fatalf("Failed to delete object: %v", err)
 	}
+	if !affected {
+		t.Fatalf("Failed to delete object")
+	}
 
 	// Validate the deletion
-	deletedToken, err := GetToken(name)
-	if err != nil || deletedToken != nil {
+	deletedToken, err := getDeletedTokenWithRetry(name)
+	if err != nil {
+		t.Fatalf("Failed to get deleted object: %v", err)
+	}
+	if deletedToken != nil {
 		t.Fatalf("Failed to delete object, it's still retrievable")
 	}
+}
+
+func getDeletedTokenWithRetry(name string) (*Token, error) {
+	var token *Token
+	var err error
+	for i := 0; i < 5; i++ {
+		token, err = GetToken(name)
+		if err == nil && token == nil {
+			return nil, nil
+		}
+		if err != nil && strings.Contains(err.Error(), "does not exist") {
+			return nil, nil
+		}
+		time.Sleep(time.Second)
+	}
+	return token, err
 }


### PR DESCRIPTION
## Summary

Fix flaky SDK integration tests that depend on the remote Casdoor demo API.

## Changes

- Treat `The token: ... does not exist` as a valid result after deleting a token
- Add short retry checks for token deletion verification
- Check mutation `affected` results in `TestPolicy`
- Add cleanup for the enforcer created by `TestPolicy`
- Fix `TestPolicy` deletion verification to check the removed policy value